### PR TITLE
Update environment variables for BSS in ochami-services.yaml

### DIFF
--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -98,7 +98,7 @@ services:
   bss:
     hostname: bss
     container_name: bss
-    image: ghcr.io/openchami/bss:v1.27.1
+    image: ghcr.io/openchami/bss:v1.27.2
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -100,10 +100,13 @@ services:
     container_name: bss
     image: ghcr.io/openchami/bss:v1.27.0
     environment:
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - SQL_USER=bss-user
-      - SQL_PASSWORD=${BSS_POSTGRES_PASSWORD} # Set in .env file
+      - BSS_USESQL=true
+      - BSS_INSECURE=true
+      - BSS_DBHOST=postgres
+      - BSS_DBNAME=ochami
+      - BSS_DBPORT=5432
+      - BSS_DBUSER=ochami
+      - BSS_DBPASS=${POSTGRES_PASSWORD} # Set in .env file
     ports:
       - '27778:27778'
     depends_on:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -98,7 +98,7 @@ services:
   bss:
     hostname: bss
     container_name: bss
-    image: ghcr.io/openchami/bss:v1.27.0
+    image: ghcr.io/openchami/bss:v1.27.1
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true


### PR DESCRIPTION
### Description

With [v1.27.2 of BSS](https://github.com/OpenCHAMI/bss/releases/tag/v1.27.2), the environment variables have changed to achieve a more granular configuration. Update those here in the `ochami-services.yaml` Docker compose file.

### Related Issues

* A response to https://github.com/OpenCHAMI/bss/pull/6
* A breadcrumb in https://github.com/OpenCHAMI/bss/issues/8