### PR TITLE
ochami deployment update

### DIFF
--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -1,10 +1,9 @@
 # Deployment Recipe for use with Docker compose
 
-
-1. `echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env`
-1. `echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env`
-1. `docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up`
-
+1. Run `./generate-config.sh` to generate an ochami config file. Default location is `/etc/ochami/ochami-config.yaml`. This can be changed by setting `OCHAMI_CONFIG=/path/to/config/ochami.yaml`
+1. Run `docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up` to bring up ochami services
+1. After a minute or so you can check the health of SMD: `curl http://<smd_host>:27779/hsm/v2/service/ready`
+1. And BSS: `curl http://<bss_host>:27778/boot/v1/service/status`
 
 ### Note on ochami-init errors
 

--- a/lanl/docker-compose/configs/ochami-template.yaml
+++ b/lanl/docker-compose/configs/ochami-template.yaml
@@ -9,14 +9,14 @@ databases:
 - name: smd
   users:
   - name: smd-init-user
-    password: 4e8a793d9c3cd3f6979f8a58bf892e3e28f0c691
+    password: SMD_DB_PASSWD
   - name: smd-user
-    password: 4e8a793d9c3cd3f6979f8a58bf892e3e28f0c691
+    password: SMD_DB_PASSWD
 - name: bssdb
   users:
   - name: bss-user
-    password: 49b29ad5469836287a0ea65f48f965159b41d60d
+    password: BSS_DB_PASSWD
 - name: hydradb
   users:
   - name: hydra-user
-    password: feec5907a0e6dc9b4f6ac99221c2252ed10d854c
+    password: HYDRA_DB_PASSWD

--- a/lanl/docker-compose/generate-configs.sh
+++ b/lanl/docker-compose/generate-configs.sh
@@ -20,6 +20,6 @@ cp configs/ochami-template.yaml $OCHAMI_CONFIG
 
 #replace passwords in template. 
 #The sed delimeter is '@' because randomly generated passwds can have slashes and sed doesn't like that
-SMDDBPASSWD="$(openssl rand -base64 32)"; sed -i "s@SMD_DB_PASSWD@$SMDDBPASSWD@" $OCHAMI_CONFIG
-BSSDBPASSWD="$(openssl rand -base64 32)"; sed -i "s@BSS_DB_PASSWD@$BSSDBPASSWD@" $OCHAMI_CONFIG
-HYDRADBPASSWD="$(openssl rand -base64 32)"; sed -i "s@HYDRA_DB_PASSWD@$HYDRADBPASSWD@" $OCHAMI_CONFIG
+SMDDBPASSWD="$(openssl rand -base64 32)"; sed -i'' -e "s@SMD_DB_PASSWD@$SMDDBPASSWD@" "${OCHAMI_CONFIG}"
+BSSDBPASSWD="$(openssl rand -base64 32)"; sed -i'' -e "s@BSS_DB_PASSWD@$BSSDBPASSWD@" ${OCHAMI_CONFIG}
+HYDRADBPASSWD="$(openssl rand -base64 32)"; sed -i'' -e "s@HYDRA_DB_PASSWD@$HYDRADBPASSWD@" ${OCHAMI_CONFIG}

--- a/lanl/docker-compose/generate-configs.sh
+++ b/lanl/docker-compose/generate-configs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Ochami config file location
+OCHAMI_CONFIG=${OCHAMI_CONFIG:-/etc/ochami/ochami-config.yaml}
+
+if [ -f $OCHAMI_CONFIG ]
+then
+	echo "A config file exists. Delete to generate a new one"
+	exit 1
+fi
+
+#Set DB passwords 
+echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
+echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+echo "OCHAMI_CONFIG=$OCHAMI_CONFIG" >> .env
+
+#Copy Config template to real config location
+mkdir -p $(dirname OCHAMI_CONFIG)
+cp configs/ochami-template.yaml $OCHAMI_CONFIG
+
+#replace passwords in template. 
+#The sed delimeter is '@' because randomly generated passwds can have slashes and sed doesn't like that
+SMDDBPASSWD="$(openssl rand -base64 32)"; sed -i "s@SMD_DB_PASSWD@$SMDDBPASSWD@" $OCHAMI_CONFIG
+BSSDBPASSWD="$(openssl rand -base64 32)"; sed -i "s@BSS_DB_PASSWD@$BSSDBPASSWD@" $OCHAMI_CONFIG
+HYDRADBPASSWD="$(openssl rand -base64 32)"; sed -i "s@HYDRA_DB_PASSWD@$HYDRADBPASSWD@" $OCHAMI_CONFIG

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -17,6 +17,9 @@ networks:
 volumes:
   postgres-data:
 
+secrets:
+  ochami-config:
+    file: ${OCHAMI_CONFIG}
 
 services:
   postgres: # Postgres
@@ -35,12 +38,13 @@ services:
       - 5432:5432
   ochami-init: # Creates the ochami databases and users
     container_name: ochami-init
-    image: ghcr.io/openchami/ochami-init:v0.0.18
+    image: ghcr.io/openchami/ochami-init:v0.0.20
     environment:
       - DB_HOST=postgres
       - DB_USER=ochami
       - DB_PASSWORD=${POSTGRES_PASSWORD} # Set in .env file
       - DB_NAME=ochami
+      - OCHAMI_CONFIG=/run/secrets/ochami-config
     hostname: ochami-init
     depends_on:
       - postgres
@@ -48,8 +52,8 @@ services:
       - internal
     entrypoint:
       - /ochami-init
-    volumes:
-      - ./configs/ochami.yaml:/config/ochami.yaml:rw
+    secrets:
+      - ochami-config
 ###
 # SMD Init and Server Containers
 ###


### PR DESCRIPTION
Updated the ochami-init version. 
Changed the compose file to use docker secrets for the ochami config file. 
added a `generate-configs.sh` script that will create the passwords and fill out the config file. 