### PR TITLE
Add bss-init, use environment variables for credentials (for now)

### DIFF
--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -1,9 +1,9 @@
 # Deployment Recipe for use with Docker compose
 
-1. Run `./generate-config.sh` to generate an ochami config file. Default location is `/etc/ochami/ochami-config.yaml`. This can be changed by setting `OCHAMI_CONFIG=/path/to/config/ochami.yaml`
 1. Run `docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up` to bring up ochami services
 1. After a minute or so you can check the health of SMD: `curl http://<smd_host>:27779/hsm/v2/service/ready`
 1. And BSS: `curl http://<bss_host>:27778/boot/v1/service/status`
+1. Run the `generate-creds.sh` script to generate a `.env` file populated with randomly-generated passwords for each Postgres database. This file will be read by Docker Compose.
 
 ### Note on ochami-init errors
 

--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -1,17 +1,35 @@
 # Deployment Recipe for use with Docker compose
 
-1. Run `docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up` to bring up ochami services
-1. After a minute or so you can check the health of SMD: `curl http://<smd_host>:27779/hsm/v2/service/ready`
-1. And BSS: `curl http://<bss_host>:27778/boot/v1/service/status`
 1. Run the `generate-creds.sh` script to generate a `.env` file populated with randomly-generated passwords for each Postgres database. This file will be read by Docker Compose.
+1. Run:
+
+   ```
+   docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up
+   ```
+
+   to bring up ochami services.
+1. After a minute or so you can check the health of SMD:
+
+   ```
+   curl http://<smd_host>:27779/hsm/v2/service/ready
+   ```
+1. And BSS:
+
+   ```
+   curl http://<bss_host>:27778/boot/v1/service/status
+   ```
 
 ### Note on ochami-init errors
 
 Docker compose doesn't dispose of ephemeral volumes unless you run
 
-`docker compose -f ochami-services.yml -f ochami-krakend-ce.yml -f hydra.yml down --volumes`
+```
+docker compose -f ochami-services.yml -f ochami-krakend-ce.yml -f hydra.yml down --volumes
+```
 
 Try disposing of the volumes if you're seeing an error that looks something like this:
 
-`ochami-init      | time="2024-01-23T17:58:49Z" level=fatal msg="pq: role \"smd-init-user\" already exists"`
-`postgres         | 2024-01-23 17:58:49.664 UTC [26] ERROR:  role "smd-init-user" already exists`
+```
+ochami-init      | time="2024-01-23T17:58:49Z" level=fatal msg="pq: role \"smd-init-user\" already exists"
+postgres         | 2024-01-23 17:58:49.664 UTC [26] ERROR:  role "smd-init-user" already exists
+```

--- a/lanl/docker-compose/generate-creds.sh
+++ b/lanl/docker-compose/generate-creds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set DB passwords
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" > .env
-echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env
-echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env
-echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env
+echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
+echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env

--- a/lanl/docker-compose/generate-creds.sh
+++ b/lanl/docker-compose/generate-creds.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set DB passwords
+echo "POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" > .env
+echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env
+echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env
+echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | sha1sum | awk '{print $1}')" >> .env

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -96,8 +96,29 @@ services:
     networks:
       - internal
 ###
-# BSS Server Container
+# BSS Init and Server Containers
 ###
+# sets up postgres for BSS data
+  bss-init:
+    hostname: bss-init
+    container_name: bss-init
+    image: ghcr.io/openchami/bss:v1.27.2
+    environment:
+      - BSS_USESQL=true
+      - BSS_INSECURE=true
+      - BSS_DBHOST=postgres
+      - BSS_DBNAME=bssdb
+      - BSS_DBPORT=5432
+      - BSS_DBUSER=bss-user
+      - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
+    ports:
+      - '27778:27778'
+    depends_on:
+      - postgres
+    networks:
+      - internal
+    entrypoint:
+      - /usr/local/bin/bss-init
   # boot-script-service
   bss:
     hostname: bss
@@ -115,6 +136,7 @@ services:
       - '27778:27778'
     depends_on:
       - postgres
+      - bss-init
       - smd
     networks:
       - internal

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -36,6 +36,11 @@ services:
       - internal
     ports:
       - 5432:5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-d", "ochami"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
   ochami-init: # Creates the ochami databases and users
     container_name: ochami-init
     image: ghcr.io/openchami/ochami-init:v0.0.20
@@ -70,8 +75,10 @@ services:
       - SMD_DBOPTS=sslmode=disable
     hostname: smd-init
     depends_on:
-      - postgres
-      - ochami-init
+      postgres:
+        condition: service_healthy
+      ochami-init:
+        condition: service_completed_successfully
     networks:
       - internal
     entrypoint:
@@ -112,7 +119,10 @@ services:
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+      ochami-init:
+        condition: service_completed_successfully
     networks:
       - internal
     entrypoint:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -45,7 +45,7 @@ services:
   # sets up postgres for SMD data
   smd-init:
     container_name: smd-init
-    image: ghcr.io/openchami/smd:v2.13.7
+    image: ghcr.io/openchami/smd:v2.13.6
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
@@ -64,7 +64,7 @@ services:
   # SMD 
   smd:
     container_name: smd
-    image: ghcr.io/openchami/smd:v2.13.7
+    image: ghcr.io/openchami/smd:v2.13.6
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -45,7 +45,7 @@ services:
   # sets up postgres for SMD data
   smd-init:
     container_name: smd-init
-    image: ghcr.io/openchami/smd:v2.13.5
+    image: ghcr.io/openchami/smd:v2.13.6
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
@@ -64,7 +64,7 @@ services:
   # SMD 
   smd:
     container_name: smd
-    image: ghcr.io/openchami/smd:v2.13.5
+    image: ghcr.io/openchami/smd:v2.13.6
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -111,8 +111,6 @@ services:
       - BSS_DBPORT=5432
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
-    ports:
-      - '27778:27778'
     depends_on:
       - postgres
     networks:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -4,10 +4,10 @@ version: '3.7'
 ## and store it in a .env file.  This file is not checked into git, so it is not
 ## shared with anyone else.  This is a temporary solution until we can use docker secrets.
 ## The generate-creds.sh script performs the following commands.
-# echo "POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" > .env
-# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
-# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
-# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
+# echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
+# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
 
 
 networks:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -102,7 +102,7 @@ services:
   bss-init:
     hostname: bss-init
     container_name: bss-init
-    image: ghcr.io/openchami/bss:v1.27.2
+    image: ghcr.io/openchami/bss:v1.28.0
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
@@ -121,7 +121,7 @@ services:
   bss:
     hostname: bss
     container_name: bss
-    image: ghcr.io/openchami/bss:v1.27.2
+    image: ghcr.io/openchami/bss:v1.28.0
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -87,7 +87,7 @@ services:
   bss-init:
     hostname: bss-init
     container_name: bss-init
-    image: ghcr.io/openchami/bss:v1.28.0
+    image: ghcr.io/openchami/bss:v1.28.1
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
@@ -107,7 +107,7 @@ services:
   bss:
     hostname: bss
     container_name: bss
-    image: ghcr.io/openchami/bss:v1.28.0
+    image: ghcr.io/openchami/bss:v1.28.1
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -45,7 +45,7 @@ services:
   # sets up postgres for SMD data
   smd-init:
     container_name: smd-init
-    image: ghcr.io/openchami/smd:v2.13.6
+    image: ghcr.io/openchami/smd:v2.13.7
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
@@ -64,7 +64,7 @@ services:
   # SMD 
   smd:
     container_name: smd
-    image: ghcr.io/openchami/smd:v2.13.6
+    image: ghcr.io/openchami/smd:v2.13.7
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -3,10 +3,11 @@ version: '3.7'
 ## Because hardcoding passwords is bad, we use openssl to generate a random password
 ## and store it in a .env file.  This file is not checked into git, so it is not
 ## shared with anyone else.  This is a temporary solution until we can use docker secrets.
-# echo "POSTGRES_PASSWORD=$(openssl rand -base64 128 | shasum)" > .env
-# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 128 | shasum)" >> .env
-# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 128 | shasum)" >> .env
-# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 128 | shasum)" >> .env
+## The generate-creds.sh script performs the following commands.
+# echo "POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" > .env
+# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
+# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
+# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 128 | sha1sum | awk '{print $1}')" >> .env
 
 
 networks:
@@ -17,10 +18,6 @@ networks:
 volumes:
   postgres-data:
 
-secrets:
-  ochami-config:
-    file: ${OCHAMI_CONFIG}
-
 services:
   postgres: # Postgres
     image: postgres:11.5-alpine
@@ -29,9 +26,10 @@ services:
     environment:
       POSTGRES_USER: ochami
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Set in .env file for now.
-      POSTGRES_DB: ochami
+      POSTGRES_MULTIPLE_DATABASES: hmsds:smd-user:${SMD_POSTGRES_PASSWORD},bssdb:bss-user:${BSS_POSTGRES_PASSWORD}
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./pg-init:/docker-entrypoint-initdb.d
     networks:
       - internal
     ports:
@@ -41,24 +39,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-  ochami-init: # Creates the ochami databases and users
-    container_name: ochami-init
-    image: ghcr.io/openchami/ochami-init:v0.0.20
-    environment:
-      - DB_HOST=postgres
-      - DB_USER=ochami
-      - DB_PASSWORD=${POSTGRES_PASSWORD} # Set in .env file
-      - DB_NAME=ochami
-      - OCHAMI_CONFIG=/run/secrets/ochami-config
-    hostname: ochami-init
-    depends_on:
-      - postgres
-    networks:
-      - internal
-    entrypoint:
-      - /ochami-init
-    secrets:
-      - ochami-config
 ###
 # SMD Init and Server Containers
 ###
@@ -69,16 +49,14 @@ services:
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
-      - SMD_DBUSER=ochami
-      - SMD_DBPASS=${POSTGRES_PASSWORD} # Set in .env file
-      - SMD_DBNAME=ochami
+      - SMD_DBUSER=smd-user
+      - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
+      - SMD_DBNAME=hmsds
       - SMD_DBOPTS=sslmode=disable
     hostname: smd-init
     depends_on:
       postgres:
         condition: service_healthy
-      ochami-init:
-        condition: service_completed_successfully
     networks:
       - internal
     entrypoint:
@@ -90,9 +68,9 @@ services:
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
-      - SMD_DBUSER=ochami
-      - SMD_DBPASS=${POSTGRES_PASSWORD} # Set in .env file
-      - SMD_DBNAME=ochami
+      - SMD_DBUSER=smd-user
+      - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
+      - SMD_DBNAME=hmsds
       - SMD_DBOPTS=sslmode=disable
     hostname: smd
     depends_on:
@@ -121,8 +99,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      ochami-init:
-        condition: service_completed_successfully
     networks:
       - internal
     entrypoint:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -126,10 +126,10 @@ services:
       - BSS_USESQL=true
       - BSS_INSECURE=true
       - BSS_DBHOST=postgres
-      - BSS_DBNAME=ochami
+      - BSS_DBNAME=bssdb
       - BSS_DBPORT=5432
-      - BSS_DBUSER=ochami
-      - BSS_DBPASS=${POSTGRES_PASSWORD} # Set in .env file
+      - BSS_DBUSER=bss-user
+      - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
     ports:
       - '27778:27778'
     depends_on:

--- a/lanl/docker-compose/pg-init/multi-psql-db.sh
+++ b/lanl/docker-compose/pg-init/multi-psql-db.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Adapted from:
+# https://github.com/mrts/docker-postgresql-multiple-databases/blob/master/create-multiple-postgresql-databases.sh
+
+set -e
+set -u
+
+function create_user_and_database() {
+	local database=$1
+	local username=$2
+	local password=$3
+	echo "  Creating user '$username' and database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	    CREATE USER "$username" WITH PASSWORD '$password';
+	    CREATE DATABASE "$database";
+	    GRANT ALL PRIVILEGES ON DATABASE "$database" TO "$username";
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for dbstr in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		dbname=$(echo $dbstr | cut -d: -f1)
+		username=$(echo $dbstr | cut -d: -f2)
+		password=$(echo $dbstr | cut -d: -f3)
+		echo "Creating: db=$dbname user=$username"
+		create_user_and_database $dbname $username $password
+	done
+	echo "Multiple databases created"
+fi


### PR DESCRIPTION
### Description

This PR addresses several things:

- Adds `bss-init` container for Postgres migrations introduced in BSS v1.28.0
- Bumps SMD to v2.13.6
- Provides a `generate-creds.sh` script to populate a `.env` file with database passwords
- Provides an init script for the `postgres` container to be able to create multiple databases/users/passwords
  - Database names, usernames, and passwords are provided via an environment variable
- Removes `ochami-init` container for initializing Postgres in favor of the init script
- Adds healthchecks to the `postgres` container for SMD and BSS to wait for Postgres to be up before attempting to connect
  - This was added when `ochami-init` was being used, since SMD and BSS needed to wait for `ochami-init` to complete and `ochami-init` needed to wait for Postgres to be ready; seems useful to keep in case needed in the future
- Edits instructions (and adjusts formatting) in `lanl/docker-compose/README.md` for new `generate-creds.sh` script

### Context

The goal of this PR is to get a working `ochami-services.yml` deployment working for testing purposes. We will eventually implement proper credential management, but using environment variables will suffice for now.