### PR TITLE
Add Helm chart to deploy simple cluster of PostgreSQL, SMD, and BSS.

### DIFF
--- a/lbnl/helm/.helmignore
+++ b/lbnl/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/lbnl/helm/Chart.yaml
+++ b/lbnl/helm/Chart.yaml
@@ -1,0 +1,15 @@
+---
+# This Helm chart deploys the PostgreSQL, SMD, and BSS components of OCHAMI.
+# Most of these deployments rely on PostgreSQL credentials to be stored in a
+# Secret called `postgres-creds`, which is not included in this repo and must be
+# created separately.
+
+apiVersion: v2
+name: ochami
+description: A Helm chart for OCHAMI
+
+type: application
+
+version: "0.0.1"
+
+appVersion: "0.0.1"

--- a/lbnl/helm/templates/bss/deployment.yaml
+++ b/lbnl/helm/templates/bss/deployment.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bss
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: bss
+spec:
+  replicas: {{ .Values.bss.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: bss
+  template:
+    metadata:
+      labels:
+        app: bss
+    spec:
+      containers:
+        - name: bss
+          image: {{ .Values.bss.deployment.image.repository }}/{{ .Values.bss.deployment.image.name }}:{{ .Values.bss.deployment.image.tag }}
+          imagePullPolicy: {{ .Values.bss.deployment.image.pullPolicy }}
+          ports:
+            - name: bss
+              containerPort: {{ .Values.bss.deployment.containerPort }}
+              protocol: TCP
+          env:
+            - name: BSS_USESQL
+              value: "true"
+            - name: BSS_INSECURE
+              value: "true"
+            - name: BSS_DBHOST
+              value: "postgres.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: BSS_DBNAME
+              value: {{ .Values.init.dbname }}
+            - name: BSS_DBPORT
+              value: "{{ .Values.postgres.service.port }}"
+            - name: BSS_DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: username
+            - name: BSS_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password

--- a/lbnl/helm/templates/bss/service.yaml
+++ b/lbnl/helm/templates/bss/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: bss
+  {{- with .Values.bss.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.bss.service.type }}
+  ports:
+    - port: {{ .Values.bss.service.port }}
+      targetPort: {{ .Values.bss.deployment.containerPort }}
+      name: bss
+  selector:
+    app: bss

--- a/lbnl/helm/templates/postgres/deployment.yaml
+++ b/lbnl/helm/templates/postgres/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: postgres
+spec:
+  replicas: {{ .Values.postgres.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.deployment.image.repository }}/{{ .Values.postgres.deployment.image.name }}:{{ .Values.postgres.deployment.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.postgres.deployment.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.deployment.containerPort }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.init.dbname }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password

--- a/lbnl/helm/templates/postgres/ochami-config.yaml
+++ b/lbnl/helm/templates/postgres/ochami-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  ochami-config.yaml: |
+    ---
+    networks:
+    - name: hardware_management
+      subnet: 10.10.10.10/24
+    - name: system_management
+      subnet: 10.10.10.10/24
+    - name: high_speed
+      subnet: 192.168.1.128/24
+    # TODO: One should of course not store passwords in a ConfigMap.
+    databases:
+    - name: smd
+      users:
+      - name: smd-init-user
+        password: SMD_DB_PASSWD
+      - name: smd-user
+        password: SMD_DB_PASSWD
+    - name: bssdb
+      users:
+      - name: bss-user
+        password: BSS_DB_PASSWD
+kind: ConfigMap
+metadata:
+  name: ochami-config
+  namespace: {{ .Release.Namespace }}

--- a/lbnl/helm/templates/postgres/ochami-init-job.yaml
+++ b/lbnl/helm/templates/postgres/ochami-init-job.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ochami-init
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: ochami-init
+        image: {{ .Values.init.job.image.repository }}/{{ .Values.init.job.image.name }}:{{ .Values.init.job.image.tag }}
+        imagePullPolicy: {{ .Values.init.job.image.pullPolicy }}
+        command: ["/ochami-init"]
+        env:
+          - name: DB_HOST
+            value: postgres.{{ .Release.Namespace }}.svc.cluster.local
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: username
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: password
+          - name: DB_NAME
+            value: {{ .Values.init.dbname }}
+          - name: OCHAMI_CONFIG
+            value: /run/secrets/ochami-config.yaml
+        volumeMounts:
+          - name: ochami-config
+            mountPath: /run/secrets
+            readOnly: true
+      volumes:
+        - name: ochami-config
+          configMap:
+            name: ochami-config
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/lbnl/helm/templates/postgres/service.yaml
+++ b/lbnl/helm/templates/postgres/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: postgres
+spec:
+  type: {{ .Values.postgres.service.type }}
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: {{ .Values.postgres.deployment.containerPort }}
+      name: postgres
+  selector:
+    app: postgres

--- a/lbnl/helm/templates/smd/deployment.yaml
+++ b/lbnl/helm/templates/smd/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: smd
+spec:
+  replicas: {{ .Values.smd.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: smd
+  template:
+    metadata:
+      labels:
+        app: smd
+    spec:
+      containers:
+        - name: smd
+          image: {{ .Values.smd.deployment.image.repository }}/{{ .Values.smd.deployment.image.name }}:{{ .Values.smd.deployment.image.tag }}
+          imagePullPolicy: {{ .Values.smd.deployment.image.pullPolicy }}
+          ports:
+            - name: smd
+              containerPort: {{ .Values.smd.deployment.containerPort }}
+              protocol: TCP
+          env:
+            - name: SMD_DBHOST
+              value: postgres.{{ .Release.Namespace }}.svc.cluster.local
+            - name: SMD_DBPORT
+              value: "{{ .Values.postgres.deployment.containerPort }}"
+            - name: SMD_DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: username
+            - name: SMD_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password
+            - name: SMD_DBNAME
+              value: {{ .Values.init.dbname }}
+            - name: SMD_DBOPTS
+              value: sslmode=disable

--- a/lbnl/helm/templates/smd/service.yaml
+++ b/lbnl/helm/templates/smd/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: smd
+  {{- with .Values.smd.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.smd.service.port }}
+      targetPort: {{ .Values.smd.deployment.containerPort }}
+      name: smd
+  selector:
+    app: smd

--- a/lbnl/helm/templates/smd/smd-init-job.yaml
+++ b/lbnl/helm/templates/smd/smd-init-job.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: smd-init
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: smd-init
+        image: {{ .Values.smd.deployment.image.repository}}/{{ .Values.smd.deployment.image.name }}:{{ .Values.smd.deployment.image.tag }}
+        imagePullPolicy: {{ .Values.smd.deployment.image.pullPolicy }}
+        command: ["/smd-init"]
+        env:
+          - name: SMD_DBHOST
+            value: postgres.{{ .Release.Namespace }}.svc.cluster.local
+          - name: SMD_DBPORT
+            value: "{{ .Values.postgres.service.port }}"
+          - name: SMD_DBUSER
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: username
+          - name: SMD_DBPASS
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: password
+          - name: SMD_DBNAME
+            value: {{ .Values.init.dbname }}
+          - name: SMD_DBOPTS
+            value: sslmode=disable
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -1,0 +1,57 @@
+---
+postgres:
+  deployment:
+    replicaCount: 1
+    image:
+      repository: ghcr.io/openchami
+      name: postgres
+      tag: "11.5-alpine"
+      pullPolicy: IfNotPresent
+    containerPort: 5432
+
+  service:
+    type: ClusterIP
+    port: 5432
+
+init:
+  job:
+    image:
+      repository: ghcr.io/openchami
+      name: ochami-init
+      tag: "v0.0.20"
+      pullPolicy: IfNotPresent
+  dbname: ochami
+
+smd:
+  deployment:
+    replicaCount: 1
+    image:
+      repository: ghcr.io/openchami
+      name: smd
+      tag: "v2.13.6"
+      pullPolicy: IfNotPresent
+    containerPort: 27779
+
+  service:
+    type: LoadBalancer
+    port: 27779
+    annotations:
+      # An annotation borrowed from CSM to select the subnet for the service.
+      metallb.universe.tf/address-pool: node-management
+
+bss:
+  deployment:
+    replicaCount: 1
+    image:
+      repository: ghcr.io/openchami
+      name: bss
+      pullPolicy: IfNotPresent
+      tag: "v1.28.1"
+    containerPort: 27778
+
+  service:
+    type: LoadBalancer
+    port: 27778
+    annotations:
+      # An annotation borrowed from CSM to select the subnet for the service.
+      metallb.universe.tf/address-pool: node-management


### PR DESCRIPTION
Fixes https://github.com/OpenCHAMI/deployment-recipes/issues/12.