### PR TITLE
Use ochami user for postgres liveness check

### DIFF
--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: ["CMD", "pg_isready", "-d", "ochami"]
+      test: ["CMD", "pg_isready", "-d", "ochami", "-U", "ochami"]
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Use the `ochami` user when doing the Postgres liveness check to avoid

```
postgres    | 2024-02-02 23:09:52.022 UTC [96] FATAL:  role "root" does not exist
```

log messages.