### PR TITLE
Update Helm chart with KrakenD and ingress integrated with GKE

### DIFF
--- a/lbnl/helm/templates/krakend/backendconfig.yaml
+++ b/lbnl/helm/templates/krakend/backendconfig.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: krakend-hc-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    port: {{ .Values.krakend.deployment.containerPort }}
+    type: HTTP
+    requestPath: /__health

--- a/lbnl/helm/templates/krakend/deployment.yaml
+++ b/lbnl/helm/templates/krakend/deployment.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: krakend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: krakend
+spec:
+  replicas: {{ .Values.krakend.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: krakend
+  template:
+    metadata:
+      labels:
+        app: krakend
+    spec:
+      containers:
+      - name: krakend
+        image: {{ .Values.krakend.deployment.image.repository }}/{{ .Values.krakend.deployment.image.name }}:{{ .Values.krakend.deployment.image.tag }}
+        imagePullPolicy: {{ .Values.krakend.deployment.image.pullPolicy }}
+        args: ["run", "-c", "/etc/krakend/krakend-config.json"]
+        env:
+          # GKE bug: https://github.com/krakend/krakend-ce/issues/260
+        - name: KRAKEND_PORT
+          value: "{{ .Values.krakend.deployment.containerPort }}"
+        ports:
+        - name: krakend
+          containerPort: {{ .Values.krakend.deployment.containerPort }}
+          protocol: TCP
+        volumeMounts:
+        - name: krakend-config
+          mountPath: /etc/krakend
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /__health
+            port: {{ .Values.krakend.deployment.containerPort }}
+      volumes:
+      - name: krakend-config
+        configMap:
+          name: krakend-config

--- a/lbnl/helm/templates/krakend/gateway.yaml
+++ b/lbnl/helm/templates/krakend/gateway.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: krakend-gateway
+  namespace: {{ .Release.Namespace }}
+spec:
+  gatewayClassName: {{ .Values.gke.gateway.class }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: {{ .Values.gke.gateway.port }}

--- a/lbnl/helm/templates/krakend/httproute.yaml
+++ b/lbnl/helm/templates/krakend/httproute.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: krakend-external
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  - name: krakend-gateway
+  rules:
+  - backendRefs:
+    - name: krakend
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.krakend.service.port }}

--- a/lbnl/helm/templates/krakend/krakend-config.yaml
+++ b/lbnl/helm/templates/krakend/krakend-config.yaml
@@ -1,0 +1,555 @@
+---
+apiVersion: v1
+data:
+  krakend-config.json: |
+    {
+      "$schema": "https://www.krakend.io/schema/krakend.json",
+      "version": 3,
+      "name": "KrakenD - API Gateway",
+      "extra_config": {
+        "telemetry/logging": {
+          "level": "ERROR",
+          "prefix": "[KRAKEND]",
+          "syslog": false,
+          "stdout": true,
+          "format": "default",
+          "syslog_facility": "local3"
+        },
+        "documentation/openapi": {
+          "version": "1.0"
+        }
+      },
+      "timeout": "3000ms",
+      "cache_ttl": "300s",
+      "output_encoding": "json",
+      "port": {{ .Values.krakend.deployment.containerPort }},
+      "debug_endpoint": true,
+      "echo_endpoint": true,
+      "endpoints": [
+        {
+          "endpoint": "/bss/{item}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/{item}",
+              "method": "GET",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/{item}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/{item}",
+              "method": "PUT",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/{item}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/{item}",
+              "method": "POST",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/{item}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/{item}",
+              "method": "PATCH",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/{item}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/{item}",
+              "method": "DELETE",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}",
+              "method": "GET",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}",
+              "method": "POST",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}",
+              "method": "PUT",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}",
+              "method": "PATCH",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}",
+              "method": "DELETE",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}/{item2}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}/{item2}",
+              "method": "GET",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}/{item2}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}/{item2}",
+              "method": "POST",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}/{item2}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}/{item2}",
+              "method": "PUT",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}/{item2}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}/{item2}",
+              "method": "PATCH",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/bss/v1/{item1}/{item2}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/boot/v1/{item1}/{item1}",
+              "method": "DELETE",
+              "host": [
+                "bss.ochami.svc.cluster.local:{{ .Values.bss.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}",
+              "method": "GET",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}",
+              "method": "PUT",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}",
+              "method": "POST",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}",
+              "method": "PATCH",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}",
+              "method": "DELETE",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}",
+              "method": "GET",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}",
+              "method": "PUT",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}",
+              "method": "POST",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}",
+              "method": "PATCH",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}",
+              "method": "DELETE",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}",
+              "method": "GET",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}",
+              "method": "PUT",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}",
+              "method": "POST",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}",
+              "method": "PATCH",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}",
+              "method": "DELETE",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+              "method": "GET",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+              "method": "PUT",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+              "method": "POST",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+              "method": "PATCH",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}",
+              "method": "DELETE",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+              "method": "GET",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+          "method": "PUT",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+              "method": "PUT",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+          "method": "POST",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+              "method": "POST",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+          "method": "PATCH",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+              "method": "PATCH",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        },
+        {
+          "endpoint": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+          "method": "DELETE",
+          "backend": [
+            {
+              "url_pattern": "/hsm/v2/{item1}/{item2}/{item3}/{item4}/{item5}",
+              "method": "DELETE",
+              "host": [
+                "smd.ochami.svc.cluster.local:{{ .Values.smd.service.port }}"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: krakend-config
+  namespace: ochami

--- a/lbnl/helm/templates/krakend/service.yaml
+++ b/lbnl/helm/templates/krakend/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: krakend
+  {{- with .Values.krakend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.krakend.service.type }}
+  ports:
+    - port: {{ .Values.krakend.service.port }}
+      targetPort: {{ .Values.krakend.deployment.containerPort }}
+      name: krakend
+  selector:
+    app: krakend

--- a/lbnl/helm/templates/smd/service.yaml
+++ b/lbnl/helm/templates/smd/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.smd.service.type }}
   ports:
     - port: {{ .Values.smd.service.port }}
       targetPort: {{ .Values.smd.deployment.containerPort }}

--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -55,3 +55,30 @@ bss:
     annotations:
       # An annotation borrowed from CSM to select the subnet for the service.
       metallb.universe.tf/address-pool: node-management
+
+krakend:
+  deployment:
+    replicaCount: 1
+    image:
+      repository: docker.io/devopsfaith
+      name: krakend
+      pullPolicy: IfNotPresent
+      tag: "2.5.1"
+    containerPort: 8080
+
+  service:
+    type: ClusterIP
+    port: 80
+    annotations:
+      # Specify which BackendConfig to use for GKE to ensure the ingress
+      # backend is healthy. The GKE docs say that sufficient annotation of the
+      # KrakenD Deployment using the standard K8s API should be sufficient to
+      # inspect the ingress backend, but I have not been successful in making
+      # that work. Specifying the BackendConfig by hand seems to help.
+      cloud.google.com/backend-config: '{"default": "krakend-hc-config"}'
+
+# Parameters specific to deploying into Google Kubernetes Engine
+gke:
+  gateway:
+    class: gke-l7-global-external-managed
+    port: 80

--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -3,7 +3,7 @@ postgres:
   deployment:
     replicaCount: 1
     image:
-      repository: ghcr.io/openchami
+      repository: docker.io
       name: postgres
       tag: "11.5-alpine"
       pullPolicy: IfNotPresent

--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -36,8 +36,6 @@ smd:
     type: ClusterIP
     port: 27779
     annotations:
-      # An annotation borrowed from CSM to select the subnet for the service.
-      metallb.universe.tf/address-pool: node-management
 
 bss:
   deployment:
@@ -53,8 +51,6 @@ bss:
     type: ClusterIP
     port: 27778
     annotations:
-      # An annotation borrowed from CSM to select the subnet for the service.
-      metallb.universe.tf/address-pool: node-management
 
 krakend:
   deployment:

--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -33,7 +33,7 @@ smd:
     containerPort: 27779
 
   service:
-    type: LoadBalancer
+    type: ClusterIP
     port: 27779
     annotations:
       # An annotation borrowed from CSM to select the subnet for the service.
@@ -50,7 +50,7 @@ bss:
     containerPort: 27778
 
   service:
-    type: LoadBalancer
+    type: ClusterIP
     port: 27778
     annotations:
       # An annotation borrowed from CSM to select the subnet for the service.


### PR DESCRIPTION
This enhances the sample Helm chart with a minimal OCHAMI cluster to include the KrakenD API gateway, along with an ingress (actually Gateway + HTTPRoute which is the K8s replacement for Ingress) integrated with Google Kubernetes Engine.

The KrakenD configuration looks long, but all it does is expose all of the existing SMD and BSS endpoints using template variables. (This is maybe not the best way to use the API gateway, but it is good enough to start with.)