### PR TITLE
Add Kratos docker compose and config to deployment recipe

### DIFF
--- a/lanl/docker-compose/configs/hydra/hydra.yml
+++ b/lanl/docker-compose/configs/hydra/hydra.yml
@@ -9,6 +9,9 @@ urls:
   login: http://127.0.0.1:3000/login
   logout: http://127.0.0.1:3000/logout
 
+strategies:
+  access_token: jwt
+
 secrets:
   system:
     - youReallyNeedToChangeThis

--- a/lanl/docker-compose/configs/kratos/identity.schema.json
+++ b/lanl/docker-compose/configs/kratos/identity.schema.json
@@ -1,0 +1,40 @@
+{
+	"$id": "https://schemas.ory.sh/presets/kratos/quickstart/email-password/identity.schema.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "Person",
+	"type": "object",
+	"properties": {
+	  "traits": {
+		"type": "object",
+		"properties": {
+		  "email": {
+			"type": "string",
+			"format": "email",
+			"title": "E-Mail",
+			"minLength": 3,
+			"ory.sh/kratos": {
+			  "credentials": {
+				"password": {
+				  "identifier": true
+				}
+			  },
+			  "verification": {
+				"via": "email"
+			  },
+			  "recovery": {
+				"via": "email"
+			  }
+			}
+		  },
+		  "website": {
+			"type": "object"
+		  }
+		},
+		"required": [
+		  "website",
+		  "email"
+		],
+		"additionalProperties": false
+	  }
+	}
+  }

--- a/lanl/docker-compose/configs/kratos/kratos.yml
+++ b/lanl/docker-compose/configs/kratos/kratos.yml
@@ -18,6 +18,22 @@ selfservice:
     - exp://localhost:8081/--/Callback
 
   methods:
+    oidc:
+      enabled: true
+      config:
+        base_redirect_uri: http://127.0.0.1
+        providers:
+          - id: gitlab
+            provider: gitlab
+            client_id: 041e5fa58113cc5891fb6c8aa9702298c9b444a7a4d9c148902625e4053dbadb
+            client_secret: a52ba279ebf2e18af53440811641ba37338aa7c6fc546b45a3bb1c869a90c6f3
+            issuer_url: https://gitlab.newmexicoconsortium.org/users/sign_in
+            mapper_url: "base://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZQp9ICsgc3RkLmV4dFZhcignY2xhaW1zJyk7Cgp7CiAgaWRlbnRpdHk6IHsKICAgIHRyYWl0czogewogICAgICAvLyBBbGxvd2luZyB1bnZlcmlmaWVkIGVtYWlsIGFkZHJlc3NlcyBlbmFibGVzIGFjY291bnQKICAgICAgLy8gZW51bWVyYXRpb24gYXR0YWNrcywgZXNwZWNpYWxseSBpZiB0aGUgdmFsdWUgaXMgdXNlZCBmb3IKICAgICAgLy8gZS5nLiB2ZXJpZmljYXRpb24gb3IgYXMgYSBwYXNzd29yZCBsb2dpbiBpZGVudGlmaWVyLgogICAgICAvLwogICAgICAvLyBUaGVyZWZvcmUgd2Ugb25seSByZXR1cm4gdGhlIGVtYWlsIGlmIGl0IChhKSBleGlzdHMgYW5kIChiKSBpcyBtYXJrZWQgdmVyaWZpZWQKICAgICAgLy8gYnkgR2l0TGFiLgogICAgICBbaWYgImVtYWlsIiBpbiBjbGFpbXMgJiYgY2xhaW1zLmVtYWlsX3ZlcmlmaWVkIHRoZW4gImVtYWlsIiBlbHNlIG51bGxdOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0K"
+            scope:
+              - read_user
+              - openid
+              - profile
+              - email 
     password:
       enabled: true
     totp:

--- a/lanl/docker-compose/configs/kratos/kratos.yml
+++ b/lanl/docker-compose/configs/kratos/kratos.yml
@@ -21,14 +21,14 @@ selfservice:
     oidc:
       enabled: true
       config:
-        base_redirect_uri: http://127.0.0.1
+        base_redirect_uri: http://127.0.0.1:4433
         providers:
           - id: gitlab
             provider: gitlab
-            client_id: 041e5fa58113cc5891fb6c8aa9702298c9b444a7a4d9c148902625e4053dbadb
-            client_secret: a52ba279ebf2e18af53440811641ba37338aa7c6fc546b45a3bb1c869a90c6f3
-            issuer_url: https://gitlab.newmexicoconsortium.org/users/sign_in
-            mapper_url: "base://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZQp9ICsgc3RkLmV4dFZhcignY2xhaW1zJyk7Cgp7CiAgaWRlbnRpdHk6IHsKICAgIHRyYWl0czogewogICAgICAvLyBBbGxvd2luZyB1bnZlcmlmaWVkIGVtYWlsIGFkZHJlc3NlcyBlbmFibGVzIGFjY291bnQKICAgICAgLy8gZW51bWVyYXRpb24gYXR0YWNrcywgZXNwZWNpYWxseSBpZiB0aGUgdmFsdWUgaXMgdXNlZCBmb3IKICAgICAgLy8gZS5nLiB2ZXJpZmljYXRpb24gb3IgYXMgYSBwYXNzd29yZCBsb2dpbiBpZGVudGlmaWVyLgogICAgICAvLwogICAgICAvLyBUaGVyZWZvcmUgd2Ugb25seSByZXR1cm4gdGhlIGVtYWlsIGlmIGl0IChhKSBleGlzdHMgYW5kIChiKSBpcyBtYXJrZWQgdmVyaWZpZWQKICAgICAgLy8gYnkgR2l0TGFiLgogICAgICBbaWYgImVtYWlsIiBpbiBjbGFpbXMgJiYgY2xhaW1zLmVtYWlsX3ZlcmlmaWVkIHRoZW4gImVtYWlsIiBlbHNlIG51bGxdOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0K"
+            client_id: 991c214d24818ac266a2aae26151ccfdb5936ab821cdf8f4fdcac7412542d76e
+            client_secret: 455593e0228f4a1a9501e57d4106e7a1b090d64122fbf0e3d2e69ba141dd3864
+            issuer_url: https://gitlab.newmexicoconsortium.org
+            mapper_url: "base64://bG9jYWwgY2xhaW1zID0gewogIGVtYWlsX3ZlcmlmaWVkOiBmYWxzZQp9ICsgc3RkLmV4dFZhcignY2xhaW1zJyk7Cgp7CiAgaWRlbnRpdHk6IHsKICAgIHRyYWl0czogewogICAgICAvLyBBbGxvd2luZyB1bnZlcmlmaWVkIGVtYWlsIGFkZHJlc3NlcyBlbmFibGVzIGFjY291bnQKICAgICAgLy8gZW51bWVyYXRpb24gYXR0YWNrcywgZXNwZWNpYWxseSBpZiB0aGUgdmFsdWUgaXMgdXNlZCBmb3IKICAgICAgLy8gZS5nLiB2ZXJpZmljYXRpb24gb3IgYXMgYSBwYXNzd29yZCBsb2dpbiBpZGVudGlmaWVyLgogICAgICAvLwogICAgICAvLyBUaGVyZWZvcmUgd2Ugb25seSByZXR1cm4gdGhlIGVtYWlsIGlmIGl0IChhKSBleGlzdHMgYW5kIChiKSBpcyBtYXJrZWQgdmVyaWZpZWQKICAgICAgLy8gYnkgR2l0TGFiLgogICAgICBbaWYgImVtYWlsIiBpbiBjbGFpbXMgJiYgY2xhaW1zLmVtYWlsX3ZlcmlmaWVkIHRoZW4gImVtYWlsIiBlbHNlIG51bGxdOiBjbGFpbXMuZW1haWwsCiAgICB9LAogIH0sCn0K"
             scope:
               - read_user
               - openid

--- a/lanl/docker-compose/configs/kratos/kratos.yml
+++ b/lanl/docker-compose/configs/kratos/kratos.yml
@@ -1,0 +1,99 @@
+version: v0.13.0
+
+dsn: memory
+
+serve:
+  public:
+    base_url: http://127.0.0.1:4433/
+    cors:
+      enabled: true
+  admin:
+    base_url: http://kratos:4434/
+
+selfservice:
+  default_browser_return_url: http://127.0.0.1:4455/
+  allowed_return_urls:
+    - http://127.0.0.1:4455
+    - http://localhost:19006/Callback
+    - exp://localhost:8081/--/Callback
+
+  methods:
+    password:
+      enabled: true
+    totp:
+      config:
+        issuer: Kratos
+      enabled: true
+    lookup_secret:
+      enabled: true
+    link:
+      enabled: true
+    code:
+      enabled: true
+
+  flows:
+    error:
+      ui_url: http://127.0.0.1:4455/error
+
+    settings:
+      ui_url: http://127.0.0.1:4455/settings
+      privileged_session_max_age: 15m
+      required_aal: highest_available
+
+    recovery:
+      enabled: true
+      ui_url: http://127.0.0.1:4455/recovery
+      use: code
+
+    verification:
+      enabled: true
+      ui_url: http://127.0.0.1:4455/verification
+      use: code
+      after:
+        default_browser_return_url: http://127.0.0.1:4455/
+
+    logout:
+      after:
+        default_browser_return_url: http://127.0.0.1:4455/login
+
+    login:
+      ui_url: http://127.0.0.1:4455/login
+      lifespan: 10m
+
+    registration:
+      lifespan: 10m
+      ui_url: http://127.0.0.1:4455/registration
+      after:
+        password:
+          hooks:
+            - hook: session
+            - hook: show_verification_ui
+
+log:
+  level: debug
+  format: text
+  leak_sensitive_values: true
+
+secrets:
+  cookie:
+    - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
+  cipher:
+    - 32-LONG-SECRET-NOT-SECURE-AT-ALL
+
+ciphers:
+  algorithm: xchacha20-poly1305
+
+hashers:
+  algorithm: bcrypt
+  bcrypt:
+    cost: 8
+
+identity:
+  default_schema_id: default
+  schemas:
+    - id: default
+      url: file:///etc/config/kratos/identity.schema.json
+
+courier:
+  smtp:
+    connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true

--- a/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
+++ b/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
@@ -1,0 +1,17 @@
+local claims = {
+  email_verified: false
+} + std.extVar('claims');
+
+{
+  identity: {
+    traits: {
+      // Allowing unverified email addresses enables account
+      // enumeration attacks, especially if the value is used for
+      // e.g. verification or as a password login identifier.
+      //
+      // Therefore we only return the email if it (a) exists and (b) is marked verified
+      // by GitHub.
+      [if "email" in claims && claims.email_verified then "email" else null]: claims.email,
+    },
+  },
+}

--- a/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
+++ b/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
@@ -13,5 +13,9 @@ local claims = {
       // by GitLab.
       [if "email" in claims && claims.email_verified then "email" else null]: claims.email,
     },
+    verified_addresses: std.prune([
+      // Carry over verified status from Social Sign-In provider.
+      if 'email' in claims && claims.email_verified then { via: 'email', value: claims.email },
+    ]),
   },
 }

--- a/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
+++ b/lanl/docker-compose/configs/kratos/oidc.gitlab.jsonnet
@@ -10,7 +10,7 @@ local claims = {
       // e.g. verification or as a password login identifier.
       //
       // Therefore we only return the email if it (a) exists and (b) is marked verified
-      // by GitHub.
+      // by GitLab.
       [if "email" in claims && claims.email_verified then "email" else null]: claims.email,
     },
   },

--- a/lanl/docker-compose/generate-creds.sh
+++ b/lanl/docker-compose/generate-creds.sh
@@ -4,4 +4,5 @@
 echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
 echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
 echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+echo "HYDRA_POSTGRES_PASSWORD=hydra" >> .env
+echo "KRATOS_POSTGRES_PASSWORD=kratos" >> .env

--- a/lanl/docker-compose/generate-creds.sh
+++ b/lanl/docker-compose/generate-creds.sh
@@ -4,5 +4,5 @@
 echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
 echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
 echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-echo "HYDRA_POSTGRES_PASSWORD=hydra" >> .env
-echo "KRATOS_POSTGRES_PASSWORD=kratos" >> .env
+echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
+echo "KRATOS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env

--- a/lanl/docker-compose/hydra.yml
+++ b/lanl/docker-compose/hydra.yml
@@ -16,8 +16,6 @@ services:
       - DSN=postgres://hydra-user:${HYDRA_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
     restart: unless-stopped
     depends_on:
-      ochami-init:
-        condition: service_completed_successfully
       hydra-migrate:
         condition: service_completed_successfully
     networks:
@@ -27,9 +25,6 @@ services:
     environment:
       - DSN=postgres://hydra-user:${HYDRA_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
-    depends_on:
-      ochami-init:
-        condition: service_completed_successfully
     volumes:
       - type: bind
         source: ./configs/hydra
@@ -40,6 +35,8 @@ services:
   consent:
     environment:
       - HYDRA_ADMIN_URL=http://hydra:4445
+      - KRATOS_ADMIN_URL=http://kratos:4434
+      - LISTEN_ADDRESS=:3000
     image: oryd/hydra-login-consent-node:v2.2.0-rc.3
     ports:
       - "3000:3000"

--- a/lanl/docker-compose/kratos.yml
+++ b/lanl/docker-compose/kratos.yml
@@ -42,10 +42,10 @@ services:
     networks:
       - internal
   kratos-selfservice-ui-node:
-    image: oryd/kratos-selfservice-ui-node:v1.0.0
+    image: oryd/kratos-selfservice-ui-node:latest
     environment:
       - KRATOS_PUBLIC_URL=http://kratos:4433/
-      - KRATOS_BROWSER_URL=http://127.0.0.1:4433/
+      - KRATOS_BROWSER_URL=http://kratos:4433/
     networks:
       - internal
     restart: on-failure

--- a/lanl/docker-compose/kratos.yml
+++ b/lanl/docker-compose/kratos.yml
@@ -1,4 +1,3 @@
-
 version: "3.7"
 services:
   kratos:
@@ -9,22 +8,31 @@ services:
       - "4455:4455"
       - "4433:4433" # public
       - "4434:4434" # admin
-    #command: serve -c /etc/config/kratos/kratos.yml all --dev --watch-courier
+    command: serve -c /etc/config/kratos/kratos.yml all --dev --watch-courier
     volumes:
       - type: bind
         source: ./configs/kratos
         target: /etc/config/kratos
     environment:
-      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/kratosdb?sslmode=disable&max_conns=20&max_idle_conns=4
     restart: unless-stopped
     depends_on:
       kratos-migrate:
         condition:
           service_completed_successfully
+      postgres:
+        condition:
+          service_healthy
+    networks:
+      - internal
   kratos-migrate:
     image: oryd/kratos:latest
+    container_name: kratos-migrate
     environment:
-      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/kratosdb?sslmode=disable&max_conns=20&max_idle_conns=4
+      - USER_ID=40946
+      - GROUP_ID=20
+    user: "${USER_ID}:${GROUP_ID}"
     volumes:
       - type: bind
         source: ./configs/kratos

--- a/lanl/docker-compose/kratos.yml
+++ b/lanl/docker-compose/kratos.yml
@@ -15,6 +15,8 @@ services:
         target: /etc/config/kratos
     environment:
       - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/kratosdb?sslmode=disable&max_conns=20&max_idle_conns=4
+      - USER_ID=$(id -u)
+      - GROUP_ID=$(id -g)
     restart: unless-stopped
     depends_on:
       kratos-migrate:
@@ -30,8 +32,8 @@ services:
     container_name: kratos-migrate
     environment:
       - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/kratosdb?sslmode=disable&max_conns=20&max_idle_conns=4
-      - USER_ID=40946
-      - GROUP_ID=20
+      - USER_ID=$(id -u)
+      - GROUP_ID=$(id -g)
     user: "${USER_ID}:${GROUP_ID}"
     volumes:
       - type: bind

--- a/lanl/docker-compose/kratos.yml
+++ b/lanl/docker-compose/kratos.yml
@@ -5,7 +5,6 @@ services:
     container_name: kratos
     hostname: kratos
     ports:
-      - "4455:4455"
       - "4433:4433" # public
       - "4434:4434" # admin
     command: serve -c /etc/config/kratos/kratos.yml all --dev --watch-courier
@@ -17,6 +16,7 @@ services:
       - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/kratosdb?sslmode=disable&max_conns=20&max_idle_conns=4
       - USER_ID=$(id -u)
       - GROUP_ID=$(id -g)
+      - LOG_LEVEL=trace
     restart: unless-stopped
     depends_on:
       kratos-migrate:
@@ -46,11 +46,20 @@ services:
   kratos-selfservice-ui-node:
     image: oryd/kratos-selfservice-ui-node:latest
     environment:
+      - PORT=4455
+      - SECURITY_MODE=
+      - HYDRA_ADMIN_URL=http://127.0.0.1:4445/
       - KRATOS_PUBLIC_URL=http://kratos:4433/
-      - KRATOS_BROWSER_URL=http://kratos:4433/
+      - KRATOS_BROWSER_URL=http://127.0.0.1:4433/
+      - COOKE_SECRET=1234567890
+      - CSRF_COOKIE_NAME=_OPENCHAMI-CSRF
+      - CSRF_COOKIE_SECRET=OCHAMI1234
+      - COOKIE_SECRET=testTESTtestTESTtestTEST
     networks:
       - internal
     restart: on-failure
+    ports:
+      - "4455:4455"
   mailslurper:
     image: oryd/mailslurper:latest-smtps
     ports:

--- a/lanl/docker-compose/kratos.yml
+++ b/lanl/docker-compose/kratos.yml
@@ -1,0 +1,50 @@
+
+version: "3.7"
+services:
+  kratos:
+    image: oryd/kratos:latest
+    container_name: kratos
+    hostname: kratos
+    ports:
+      - "4455:4455"
+      - "4433:4433" # public
+      - "4434:4434" # admin
+    #command: serve -c /etc/config/kratos/kratos.yml all --dev --watch-courier
+    volumes:
+      - type: bind
+        source: ./configs/kratos
+        target: /etc/config/kratos
+    environment:
+      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
+    restart: unless-stopped
+    depends_on:
+      kratos-migrate:
+        condition:
+          service_completed_successfully
+  kratos-migrate:
+    image: oryd/kratos:latest
+    environment:
+      - DSN=postgres://kratos-user:${KRATOS_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
+    volumes:
+      - type: bind
+        source: ./configs/kratos
+        target: /etc/config/kratos
+    command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
+    restart: on-failure
+    networks:
+      - internal
+  kratos-selfservice-ui-node:
+    image: oryd/kratos-selfservice-ui-node:v1.0.0
+    environment:
+      - KRATOS_PUBLIC_URL=http://kratos:4433/
+      - KRATOS_BROWSER_URL=http://127.0.0.1:4433/
+    networks:
+      - internal
+    restart: on-failure
+  mailslurper:
+    image: oryd/mailslurper:latest-smtps
+    ports:
+      - '4436:4436'
+      - '4437:4437'
+    networks:
+      - internal

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_USER: ochami
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Set in .env file for now.
-      POSTGRES_MULTIPLE_DATABASES: hmsds:smd-user:${SMD_POSTGRES_PASSWORD},bssdb:bss-user:${BSS_POSTGRES_PASSWORD}
+      POSTGRES_MULTIPLE_DATABASES: hmsds:smd-user:${SMD_POSTGRES_PASSWORD},bssdb:bss-user:${BSS_POSTGRES_PASSWORD},kratosdb:kratos-user:${KRATOS_POSTGRES_PASSWORD}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./pg-init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
This PR adds a separate docker compose file to the deployment recipes. Adding Kratos will allow the use of SSO with GitLab that will allow users to authorize the OpenCHAMI client to receive ID tokens for authentication.

This PR will be complete after
- Integrating Kratos with Hydra
- Work out issue with GitLab response
