### PR TITLE
generate-creds.sh: Hash openssl output with `openssl dgst`

### DIFF
--- a/lanl/docker-compose/generate-creds.sh
+++ b/lanl/docker-compose/generate-creds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set DB passwords
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
-echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+echo "POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" > .env
+echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
+echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
+echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -4,10 +4,10 @@ version: '3.7'
 ## and store it in a .env file.  This file is not checked into git, so it is not
 ## shared with anyone else.  This is a temporary solution until we can use docker secrets.
 ## The generate-creds.sh script performs the following commands.
-# echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" > .env
-# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
-# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> .env
+# echo "POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" > .env
+# echo "SMD_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
+# echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
+# echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
 
 
 networks:


### PR DESCRIPTION
This is to avoid '/' appearing in passwords which cause conflicts in the Postgres DSN.