### PR TITLE
hydra.yml: Correct curl health check command to wget

### DIFF
--- a/lanl/docker-compose/hydra.yml
+++ b/lanl/docker-compose/hydra.yml
@@ -4,7 +4,7 @@ services:
   hydra:
     image: oryd/hydra:v2.2.0-rc.3
     healthcheck:
-        test: ["CMD", "curl", "-f", "http://127.0.0.1:4444/health/alive"]
+        test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:4444/health/alive"]
         interval: 10s
         timeout: 10s
         retries: 10


### PR DESCRIPTION
It turns out, curl is not present in the `hydra` container image, but `wget` is.

Amends https://github.com/OpenCHAMI/deployment-recipes/pull/16.