### PR TITLE
Added hydra parameters to config to work with opaal

### DIFF
--- a/lanl/docker-compose/configs/hydra/hydra.yml
+++ b/lanl/docker-compose/configs/hydra/hydra.yml
@@ -23,5 +23,12 @@ oidc:
     pairwise:
       salt: ${HYDRA_OIDC_SALT} # set in .env
 
+oauth2:
+  grant:
+    jwt:
+      jti_optional: true
+      iat_optional: true
+      max_ttl: 24h
+
 strategies:
   access_token: jwt


### PR DESCRIPTION
This PR adds a few parameters needed for automated login flows with `opaal` in Hydra's config. If we decide we need these options enabled later, they can be added to the JWT claims that `opaal` sends to the authorization server.