### PR TITLE
update environment for dnsmasq-dhcp 

### DIFF
--- a/lanl/docker-compose/ochami-services-noauth.yml
+++ b/lanl/docker-compose/ochami-services-noauth.yml
@@ -146,8 +146,10 @@ services:
     container_name: dnsmasq-dhcp-noauth
     hostname: dnsmasq-dhcp-noauth
     environment:
-      - smd_endpoint=172.16.0.253
-      - bss_endpoint=172.16.0.253
+      - smd_endpoint=localhost
+      - smd_port=27799
+      - bss_endpoint=localhost
+      - bss_port=27788
     depends_on:
       bss-noauth:
         condition: service_healthy

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -158,8 +158,10 @@ services:
     container_name: dnsmasq-dhcp
     hostname: dnsmasq-dhcp
     environment:
-      - smd_endpoint=172.16.0.253
-      - bss_endpoint=172.16.0.253
+      - smd_endpoint=localhost
+      - smd_port=27779
+      - bss_endpoint=localhost
+      - bss_port=27778
     depends_on:
       bss:
         condition: service_healthy


### PR DESCRIPTION
Changed the BSS and SMD endpoints to use localhost instead of a hardcoded IP. 
Added port variables to work with newer dnsmasq-dhcp container image (see https://github.com/OpenCHAMI/dnsmasq-dhcpd/pull/9). 