### PR TITLE
Add OPAAL

### DIFF
--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -9,13 +9,13 @@
 - `ochami-services-noauth.yml`: Like `ochami-services.yml`, but runs SMD and BSS
   with JWT authentication disabled. This file can be run independently of or
   alongside `ochami-services.yml`.
-- `ochami-hurl-tests.yaml`: Runs integration tests using Hurl against the
+- `ochami-hurl-tests.yml`: Runs integration tests using Hurl against the
   authentication-enabled BSS and SMD in `ochami-services.yml`.
 - `ochami-hurl-tests-noauth.yml`: Runs integration tests using Hurl against the
   authentication-disabled BSS and SMD in `ochami-services-noauth.yml`.
 - `ochami-krakend-ce.yml`: Runs the Krakend-CE API gateway for SMD and BSS.
 - `hydra.yml`: Runs the Hydra OAuth2/OIDC server used for authentication-enabled
-  BSS and SMD.
+  BSS and SMD. This file is a dependency of `ochami-services.yml`.
 
 ## Running Deployments
 

--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -13,6 +13,9 @@
   authentication-enabled BSS and SMD in `ochami-services.yml`.
 - `ochami-hurl-tests-noauth.yml`: Runs integration tests using Hurl against the
   authentication-disabled BSS and SMD in `ochami-services-noauth.yml`.
+- `opaal.yml`: Runs the OPAAL OIDC login helper tool. BSS requests a token from
+  OPAAL, which then reaches out to Hydra to verify the client. This file is a
+  dependency of `ochami-services.yml`.
 - `ochami-krakend-ce.yml`: Runs the Krakend-CE API gateway for SMD and BSS.
 - `hydra.yml`: Runs the Hydra OAuth2/OIDC server used for authentication-enabled
   BSS and SMD. This file is a dependency of `ochami-services.yml`.
@@ -29,7 +32,7 @@
    To run the services with JWT authentication enabled:
 
    ```
-   docker compose -f ochami-services.yml -f hydra.yml -f ochami-krakend-ce.yml up
+   docker compose -f ochami-services.yml -f hydra.yml -f opaal.yml -f ochami-krakend-ce.yml up
    ```
 
    **NOTE:** Authenticated BSS and SMD run on host ports 27778 and 27779,
@@ -51,6 +54,7 @@
      -f ochami-services.yml \
      -f ochami-services-noauth.yml \
      -f hydra.yml \
+     -f opaal.yml \
      -f ochami-krakend-ce.yml \
      up
    ```

--- a/lanl/docker-compose/configs/opaal.yaml
+++ b/lanl/docker-compose/configs/opaal.yaml
@@ -1,0 +1,53 @@
+version: "0.0.1"
+server:
+  host: "0.0.0.0"
+  port: 3333
+  callback: "/oidc/callback"
+
+providers:
+  gitlab: "https://gitlab.newmexicoconsortium.org"
+
+authentication:
+  state: ""
+  test-all: false
+  clients:
+    - id: "7c0fab1153674a258a705976fcb9468350df3addd91de4ec622fc9ed24bfbcdd"
+      secret: "a9a8bc55b0cd99236756093adc00ab17855fa507ce106b8038e7f9390ef2ad99"
+      name: "gitlab"
+      issuer: "http://gitlab.newmexicoconsortium.org"
+      scope:
+        - "openid"
+        - "profile"
+        - "email"
+      redirect-uris:
+        - "http://opaal:3333/oidc/callback"
+
+authorization:
+  token:
+    forwarding: false
+    refresh: false
+    duration: 16h
+    scope:
+      - smd.read
+  token-duration: 16h
+  token-forwarding: false
+  key-path: ./keys
+  endpoints:
+    issuer: http://hydra:4444
+    config: http://hydra:4444/.well-known/openid-configuration
+    jwks: http://hydra:4444/.well-known/jwks.json
+    #identities: http://hydra:4434/admin/identities
+    trusted-issuers: http://hydra:4445/admin/trust/grants/jwt-bearer/issuers
+    #login: http://127.0.0.1:4433/self-service/login/api
+    clients: http://hydra:4445/admin/clients
+    authorize: http://hydra:4444/oauth2/auth
+    register: http://hydra:4444/oauth2/register
+    token: http://hydra:4444/oauth2/token
+
+
+options:
+  run-once: true
+  open-browser: false
+  flow: authorization_code
+  cache-only: false
+  verbose: true

--- a/lanl/docker-compose/ochami-services-noauth.yml
+++ b/lanl/docker-compose/ochami-services-noauth.yml
@@ -95,7 +95,7 @@ services:
   bss-init-noauth:
     hostname: bss-init-noauth
     container_name: bss-init-noauth
-    image: ghcr.io/openchami/bss:v1.30.1
+    image: ghcr.io/openchami/bss:v1.30.2
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
@@ -115,7 +115,7 @@ services:
   bss-noauth:
     hostname: bss-noauth
     container_name: bss-noauth
-    image: ghcr.io/openchami/bss:v1.30.1
+    image: ghcr.io/openchami/bss:v1.30.2
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -130,9 +130,9 @@ services:
       - BSS_DBNAME=bssdb
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
-      - BSS_JWKS_URL=http://hydra:4444/.well-known/jwks.json
-      - BSS_OAUTH2_ADMIN_BASE_URL=http://hydra:4445
-      - BSS_OAUTH2_PUBLIC_BASE_URL=http://hydra:4444
+      - BSS_JWKS_URL=http://opaal:3333/keys
+      - BSS_OAUTH2_ADMIN_BASE_URL=http://opaal:3333
+      - BSS_OAUTH2_PUBLIC_BASE_URL=http://opaal:3333
     ports:
       - '27778:27778'
     depends_on:
@@ -146,6 +146,8 @@ services:
         condition: service_healthy
       hydra-gen-jwks:
         condition: service_completed_successfully
+      opaal:
+        condition: service_healthy
     networks:
       - internal
     healthcheck:

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -98,7 +98,7 @@ services:
 ###
 # sets up postgres for BSS data
   bss-init:
-    image: ghcr.io/openchami/bss:v1.30.1
+    image: ghcr.io/openchami/bss:v1.30.2
     container_name: bss-init
     hostname: bss-init
     environment:
@@ -118,7 +118,7 @@ services:
       - /usr/local/bin/bss-init
   # boot-script-service
   bss:
-    image: ghcr.io/openchami/bss:v1.30.1
+    image: ghcr.io/openchami/bss:v1.30.2
     container_name: bss
     hostname: bss
     environment:

--- a/lanl/docker-compose/opaal.yml
+++ b/lanl/docker-compose/opaal.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+
+services:
+  opaal:
+    image: ghcr.io/openchami/opaal:0.1
+    container_name: opaal
+    hostname: opaal
+    command:
+      - '/opaal/opaal'
+      - 'login'
+      - '--config'
+      - '/opaal/config.yaml'
+    volumes:
+      - ./configs/opaal.yaml:/opaal/config.yaml
+    networks:
+      - internal
+    ports:
+      - 3333:3333
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:3333/status"]
+      interval: 5s
+      timeout: 10s
+      retries: 60


### PR DESCRIPTION
[OPAAL](https://github.com/OpenCHAMI/opaal) is an OIDC login tool that greatly eases the login workflow for client credentials grants. BSS added support for it in v1.30.2.

This PR adds a docker-compose config for OPAAL and configures BSS to depend on the service as well as use it for fetching its JWKS, which BSS uses to authenticate with SMD's protected endpoints.