### PR TITLE
Add missing docker compose verb from, remove Krakend from noauth services in lanl docker-compose README

### DIFF
--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -41,7 +41,7 @@
    To run the services without JWT authentication enabled:
 
    ```
-   docker compose -f ochami-services-noauth.yml -f ochami-krakend-ce.yml
+   docker compose -f ochami-services-noauth.yml -f ochami-krakend-ce.yml up
    ```
 
    **NOTE:** Non-authenticated BSS and SMD run on host ports 37778 and 37779,

--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -41,7 +41,7 @@
    To run the services without JWT authentication enabled:
 
    ```
-   docker compose -f ochami-services-noauth.yml -f ochami-krakend-ce.yml up
+   docker compose -f ochami-services-noauth.yml up
    ```
 
    **NOTE:** Non-authenticated BSS and SMD run on host ports 37778 and 37779,


### PR DESCRIPTION
Until the organization of the authenticated versus unauthenticated services is determined, Krakend will not be used in the unauthenticated tests. Also fix directions to add missing Docker Compose `up` from step running unauthenticated tests.

Addresses #36. 