### PR TITLE
Add cloud-init service

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -53,13 +53,15 @@ This quickstart makes a few assumptions about the target operating system and is
    curl --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN" https://foobar.openchami.cluster/hsm/v2/State/Components
    # This should respond with an empty set of Components: {"Components":[]}
    ```
-1. Create a token that can be used by the dnsmasq-loader which reads from smd.  This activates our automatic dns/dhcp system.  The command automatically adds it to .env
+1. Create tokens for services that need to read from SMD and can't request tokens directly and add them to the `.env` file.
+   Both cloud-init and dnsmasq-loader rely on acces to SMD to update their local caches of node information.
    ```bash
     echo "DNSMASQ_ACCESS_TOKEN=$(gen_access_token)" >> .env
+    echo "CLOUD_INIT_ACCESS_TOKEN=$(gen_access_token)" >> .env
     ```
 1. Use docker-compose to bring up your dnsmasq contianers.  The only difference between this command and the one above is the addition of the `dnsmasq.yml` file.  Docker compose needs to know about all the files to follow dependencies.
    ```bash
-   docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f openchami-svcs.yml -f autocert.yml -f dnsmasq.yml up -d
+   docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-gateway.yml -f openchami-svcs.yml -f autocert.yml -f dnsmasq.yml -f cloud-init.yml up -d
    ```
 
 
@@ -85,10 +87,10 @@ docker compose -f base.yml -f postgres.yml -f jwt-security.yml -f haproxy-api-ga
 This quickstart uses `docker compose` to start up services and define dependencies.  If you have a basic understanding of docker, you should be able to work with the included services.  Some handy items to remember for when you are exploring the deployment are below.
 
 
-`docker volume list` This lists all the volumes.  If they exist, the project will try to reuse them.  That might not be what you want.
-`docker network list` ditto for networks
-`docker ps -a` the -a shows you containers that aren't running.  We have several containers that are designed to do their thing and then exit.
-`docker logs <container-id>` allows you to check the logs of containers even after they have exited
-`docker compose ... down --volumes` will not only bring down all the services, but also delete the volumes
+- `docker volume list` This lists all the volumes.  If they exist, the project will try to reuse them.  That might not be what you want.
+- `docker network list` ditto for networks
+- `docker ps -a` the -a shows you containers that aren't running.  We have several containers that are designed to do their thing and then exit.
+- `docker logs <container-id>` allows you to check the logs of containers even after they have exited
+- `docker compose ... down --volumes` will not only bring down all the services, but also delete the volumes
 
 ## Going even further

--- a/quickstart/cloud-init.yml
+++ b/quickstart/cloud-init.yml
@@ -1,0 +1,18 @@
+
+services:
+  cloud-init:
+    image: ghcr.io/openchami/cloud-init:v0.0.9
+    container_name: cloud-init
+    hostname: cloud-init
+    restart: always
+    networks:
+      - internal
+    environment:
+      - SMD_TOKEN=${CLOUD_INIT_ACCESS_TOKEN}
+    depends_on:
+      - smd
+    healthcheck:
+      test: ["CMD", "pgrep", "cloud-init-server"]
+      interval: 5s
+      timeout: 10s
+      retries: 60

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -1,8 +1,12 @@
 global
   stats socket /var/run/api.sock user haproxy group haproxy mode 660 level admin expose-fd listeners
-  log stdout format raw local0 info
+  log stdout local0 info
+  
   fd-hard-limit 50000
   ssl-default-bind-options ssl-min-ver TLSv1.3 no-tls-tickets
+
+resolvers dockerdns
+  nameserver dns 127.0.0.11:53
 
 defaults
   mode http
@@ -21,6 +25,7 @@ frontend stats
 frontend openchami
   bind :80
   bind :443 ssl crt /etc/haproxy/certs/ strict-sni
+  option httplog
   option forwardfor
 
   acl PATH_smd path_beg -i /hsm/v2
@@ -46,19 +51,24 @@ frontend openchami
   use_backend opaal-idp if PATH_opaal-idp
   use_backend smd if PATH_smd
   use_backend bss if PATH_bss
+  use_backend cloud-init if PATH_cloud-init
 
 backend opaal
-  server opaal opaal:3333
+  server opaal opaal:3333 check resolvers dockerdns init-addr libc,none
 
 backend opaal-idp
-  server opaal-idp opaal-idp:3332
+  server opaal-idp opaal-idp:3332 check resolvers dockerdns init-addr libc,none
 
-backend smd
-  server smd smd:27779
+backend smd 
+  server smd smd:27779 check resolvers dockerdns init-addr libc,none
 
 backend bss
-  server bss bss:27778
+  server bss bss:27778 check resolvers dockerdns init-addr libc,none
   http-request replace-path ^/apis/bss/(.*) /\1
+
+backend cloud-init
+  server cloud-init cloud-init:27777 check resolvers dockerdns init-addr libc,none
+
 
 
 


### PR DESCRIPTION
This commit adds a new service called cloud-init to the quickstart deployment. The cloud-init service is responsible for delivering cloud-init payloads based on the contents of SMD. It is dependent on the smd service and uses the CLOUD_INIT_ACCESS_TOKEN environment variable for authentication.

There are correspoonding changes to haproxy where I have also made improvements to logging and possible race conditions for starting services.

The README has been updated as well to cover the addition of this container