### PR TITLE
Add ability to use custom cluster domain

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -24,6 +24,7 @@ This quickstart makes a few assumptions about the target operating system and is
     - __Note__ The certificates for the system use the name you provide in this file.  It's not easy to change.
     - __Note__ The script attempts to figure out which ip address is most likely to be your system ip.  If it is unsuccessful, `LOCAL_IP=` will be empty and you'll need to update it manually
     - __Note__ The full url will be https://foobar.openchami.cluster which you should set manually in /etc/hosts and point to the same ip address as `LOCAL_IP` in `.env`.
+    - __Note__ The `generate-configs.sh` script accepts an optional second argument that allows a custom domain to be specified. If not specified, it defaults to "openchami.cluster", which is used throughout these instructions.
    
    ```bash
    # Create the secrets in the .env file.  Do not share them with anyone. 

--- a/quickstart/configs/.gitignore
+++ b/quickstart/configs/.gitignore
@@ -1,0 +1,1 @@
+opaal.yaml

--- a/quickstart/configs/opaal-template.yaml
+++ b/quickstart/configs/opaal-template.yaml
@@ -7,13 +7,13 @@ server:
     host: "opaal-idp"
     port: 3332
     endpoints:
-      authorization: "https://<your-subdomain-here>.openchami.cluster/oauth2/authorize"
+      authorization: "https://<your-subdomain-here>.<your-domain-here>/oauth2/authorize"
     clients:
       - id: openchami
         secret: openchami
         name: openchami
         redirect-uris:
-          - "https://<your-subdomain-here>.openchami.cluster/oidc/callback"
+          - "https://<your-subdomain-here>.<your-domain-here>/oidc/callback"
 
 authentication:
   state: ""
@@ -25,7 +25,7 @@ authentication:
       provider: 
         issuer: "http://opaal-idp:3332"
       redirect-uris:
-        - "https://<your-subdomain-here>.openchami.cluster/oidc/callback"
+        - "https://<your-subdomain-here>.<your-domain-here>/oidc/callback"
     - id: "<gitlab-client-id>"
       secret: "<gitlab-client-secret>"
       name: "gitlab"
@@ -36,7 +36,7 @@ authentication:
         - "profile"
         - "email"
       redirect-uris:
-        - "https://<your-subdomain-here>.openchami.cluster/oidc/callback"
+        - "https://<your-subdomain-here>.<your-domain-here>/oidc/callback"
 
 authorization:
   token:
@@ -46,7 +46,7 @@ authorization:
     scope:
       - smd.read
   audience: 
-    - https://<your-subdomain-here>.openchami.cluster/oauth2/token
+    - https://<your-subdomain-here>.<your-domain-here>/oauth2/token
   key-path: ./keys
   endpoints:
     issuer: http://hydra:4444

--- a/quickstart/dnsmasq.yml
+++ b/quickstart/dnsmasq.yml
@@ -22,7 +22,7 @@ services:
     container_name: dnsmasq-loader
     hostname: dnsmasq-loader
     environment:
-      - OCHAMI_BASEURL=https://${SYSTEM_NAME}.openchami.cluster
+      - OCHAMI_BASEURL=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}
       - OCHAMI_ACCESS_TOKEN=${DNSMASQ_ACCESS_TOKEN}
       - CURL_CA_BUNDLE=/root_ca/root_ca.crt
     volumes:
@@ -30,7 +30,7 @@ services:
       - step-root-ca:/root_ca/:ro
       - dnsmasq-hostsfiles:/configs/site/hosts/:rw
     extra_hosts:
-      - "${SYSTEM_NAME}.openchami.cluster:${LOCAL_IP}"
+      - "${SYSTEM_NAME}.${SYSTEM_DOMAIN}:${LOCAL_IP}"
     depends_on:
       haproxy:
         condition: service_healthy

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -11,12 +11,24 @@ then
 	echo "An OPAAL config (configs/opaal.yaml) exists. Delete to generate a new one"
 fi
 
+usage() {
+	echo "Usage: $0 system-name [system-domain]"
+	echo "Example: $0 foobar openchami.cluster"
+	echo "Example: $0 foobar"
+	echo ""
+	echo "Generate configuration for OpenCHAMI quickstart."
+	echo ""
+	echo "ARGUMENTS:"
+	echo " system-name   Subdomain of system to use in certificate and config"
+	echo "               generation. E.g. <system-name>.openchami.cluster"
+	echo " system-domain (OPTIONAL) Domain of system to use in certificate and"
+	echo "               config generation. Defaults to openchami.cluster"
+}
+
 SYSNAME="$1"
 if [ -z "$SYSNAME" ]
 then
-	echo "Usage: $0 system-name [domain]"
-	echo "Example: $0 foobar openchami.cluster"
-	echo "Example: $0 foobar"
+	usage >&2
 	exit 1
 fi
 

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -6,6 +6,11 @@ then
 	exit 1
 fi
 
+if [ -f configs/opaal.yaml ]
+then
+	echo "An OPAAL config (configs/opaal.yaml) exists. Delete to generate a new one"
+fi
+
 SYSNAME="$1"
 if [ -z "$SYSNAME" ]
 then

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -6,10 +6,19 @@ then
 	exit 1
 fi
 
-if [ -z "$1" ]
+SYSNAME="$1"
+if [ -z "$SYSNAME" ]
 then
-	echo "Usage: $0 system-name"
+	echo "Usage: $0 system-name [domain]"
+	echo "Example: $0 foobar openchami.cluster"
+	echo "Example: $0 foobar"
 	exit 1
+fi
+
+SYSDOMAIN="openchami.cluster"
+if [ -n "$2" ]
+then
+	SYSDOMAIN="$2"
 fi
 
 if [[ ! -x $(command -v jq) ]]
@@ -36,8 +45,9 @@ echo "# This file is used by docker compose to set environment variables" > .env
 echo "# For more information about how it is read and how to override items in it, see the docs:" >> .env
 echo "#   https://docs.docker.com/compose/environment-variables/set-environment-variables/" >> .env
 
-# Set the system name which is used for certs
-echo "SYSTEM_NAME=$1" >> .env
+# Set the system name and domain hich are used for certs
+echo "SYSTEM_NAME=$SYSNAME" >> .env
+echo "SYSTEM_DOMAIN=$SYSDOMAIN" >> .env
 # Set DB passwords 
 echo "POSTGRES_PASSWORD=$(generate_random_alphanumeric 32)" >> .env
 echo "BSS_POSTGRES_PASSWORD=$(generate_random_alphanumeric 32)" >> .env

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -25,6 +25,7 @@ usage() {
 	echo "               config generation. Defaults to openchami.cluster"
 }
 
+# Parse system name (required arg).
 SYSNAME="$1"
 if [ -z "$SYSNAME" ]
 then
@@ -32,6 +33,7 @@ then
 	exit 1
 fi
 
+# Parse system domain (optional arg).
 SYSDOMAIN="openchami.cluster"
 if [ -n "$2" ]
 then

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -46,6 +46,12 @@ then
 	exit 1 
 fi
 
+if [[ ! -x $(command -v sed) ]]
+then
+        echo "Command \"sed\" Not Found"
+	exit 1
+fi
+
 get_eth0_ipv4() {
  local ipv4
  local first_eth=$(ip -j addr | jq -c '.[]' | grep UP |grep -v veth | grep -v LOOPBACK |grep -v br- |grep -v NO-CARRIER | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -n 1 | jq -rc '.ifname')

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -41,14 +41,14 @@ then
 fi
 
 if [[ ! -x $(command -v jq) ]]
-then 
-        echo "Command \"jq\" Not Found"
-	exit 1 
+then
+	echo "Command \"jq\" not found"
+	exit 1
 fi
 
 if [[ ! -x $(command -v sed) ]]
 then
-        echo "Command \"sed\" Not Found"
+	echo "Command \"sed\" not found"
 	exit 1
 fi
 
@@ -80,7 +80,7 @@ echo "#   https://docs.docker.com/compose/environment-variables/set-environment-
 # Set the system name and domain hich are used for certs
 echo "SYSTEM_NAME=$SYSNAME" >> .env
 echo "SYSTEM_DOMAIN=$SYSDOMAIN" >> .env
-# Set DB passwords 
+# Set DB passwords
 echo "POSTGRES_PASSWORD=$(generate_random_alphanumeric 32)" >> .env
 echo "BSS_POSTGRES_PASSWORD=$(generate_random_alphanumeric 32)" >> .env
 echo "SMD_POSTGRES_PASSWORD=$(generate_random_alphanumeric 32)" >> .env

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -39,6 +39,13 @@ generate_random_alphanumeric() {
 	  cat /dev/urandom | tr -dc '[:alnum:]' | fold -w "$num_chars" | head -n 1
 }
 
+# Generate OPAAL config from configs/opaal-template.yaml. This will populate the
+# system name and domain of the config with the values set for SYSTEM_NAME and
+# SYSTEM_DOMAIN in this script.
+# TODO: Populate GitLab information in OPAAL config.
+sed "s/<your-subdomain-here>/${SYSTEM_NAME}/g" configs/opaal-template.yaml > configs/opaal.yaml
+sed "s/<your-domain-here>/${SYSTEM_DOMAIN}/g" configs/opaal-template.yaml > configs/opaal.yaml
+
 
 # Set the system name
 echo "# This file is used by docker compose to set environment variables" > .env

--- a/quickstart/generate-configs.sh
+++ b/quickstart/generate-configs.sh
@@ -2,7 +2,7 @@
 
 if [ -f .env ]
 then
-	echo "A config file exists. Delete to generate a new one"
+	echo "A config file (.env) exists. Delete to generate a new one"
 	exit 1
 fi
 

--- a/quickstart/haproxy-api-gateway.yml
+++ b/quickstart/haproxy-api-gateway.yml
@@ -32,7 +32,7 @@ services:
       - ./configs/:/usr/local/etc/haproxy/:ro
       - haproxy-certs:/etc/haproxy/certs/:ro
   acme-register:
-    container_name: ${SYSTEM_NAME}.openchami.cluster
+    container_name: ${SYSTEM_NAME}.${SYSTEM_DOMAIN}
     image: ghcr.io/openchami/acme.sh:v0.2.2
     networks:
       - cert-internal
@@ -42,7 +42,7 @@ services:
     volumes:
       - step-root-ca:/root_ca/:ro
       - acme-certs:/root/.acme.sh
-    entrypoint: ["/usr/bin/acme.sh", "--server", "https://step-ca:9000/acme/acme/directory", "--ca-bundle", "/root_ca/root_ca.crt", "-d", "${SYSTEM_NAME}.openchami.cluster", "--issue", "--standalone", "--force"]
+    entrypoint: ["/usr/bin/acme.sh", "--server", "https://step-ca:9000/acme/acme/directory", "--ca-bundle", "/root_ca/root_ca.crt", "-d", "${SYSTEM_NAME}.${SYSTEM_DOMAIN}", "--issue", "--standalone", "--force"]
   acme-deploy:
     container_name: acme-deploy
     image: ghcr.io/openchami/acme.sh:v0.2.2
@@ -57,4 +57,4 @@ services:
       - haproxy-certs:/root/certs/
     environment:
       - DEPLOY_HAPROXY_PEM_PATH=/root/certs/
-    entrypoint: ["/usr/bin/acme.sh", "--server", "https://step-ca:9000/acme/acme/directory", "--ca-bundle", "/root_ca/root_ca.crt", "--deploy", "--deploy-hook", "haproxy", "--domain", "${SYSTEM_NAME}.openchami.cluster"]
+    entrypoint: ["/usr/bin/acme.sh", "--server", "https://step-ca:9000/acme/acme/directory", "--ca-bundle", "/root_ca/root_ca.crt", "--deploy", "--deploy-hook", "haproxy", "--domain", "${SYSTEM_NAME}.${SYSTEM_DOMAIN}"]

--- a/quickstart/jwt-security.yml
+++ b/quickstart/jwt-security.yml
@@ -34,7 +34,7 @@ services:
       - internal
       - jwt-internal
     extra_hosts:
-      - "${SYSTEM_NAME}.openchami.cluster:${LOCAL_IP}"
+      - "${SYSTEM_NAME}.${SYSTEM_DOMAIN}:${LOCAL_IP}"
 
     healthcheck:
       test: ["CMD", "curl", "--fail", "--silent", "http://opaal:3333/keys"]
@@ -64,11 +64,11 @@ services:
       - ./configs/:/etc/config/hydra
     environment:
       - SECRETS_SYSTEM=${HYDRA_SYSTEM_SECRET} # set in .env
-      - URLS_SELF_ISSUER=https://${SYSTEM_NAME}.openchami.cluster/
-      - URLS_SELF_PUBLIC=https://${SYSTEM_NAME}.openchami.cluster/
-      - URLS_LOGIN=https://${SYSTEM_NAME}.openchami.cluster/login
-      - URLS_CONSENT=https://${SYSTEM_NAME}.openchami.cluster/consent
-      - URLS_LOGOUT=https://${SYSTEM_NAME}.openchami.cluster/logout
+      - URLS_SELF_ISSUER=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}/
+      - URLS_SELF_PUBLIC=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}/
+      - URLS_LOGIN=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}/login
+      - URLS_CONSENT=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}/consent
+      - URLS_LOGOUT=https://${SYSTEM_NAME}.${SYSTEM_DOMAIN}/logout
       - DSN=postgres://hydra-user:${HYDRA_POSTGRES_PASSWORD}@postgres:5432/hydradb?sslmode=disable&max_conns=20&max_idle_conns=4
     restart: unless-stopped
     depends_on:

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -91,7 +91,7 @@ services:
       - BSS_JWKS_URL=http://opaal:3333/keys
       - BSS_OAUTH2_ADMIN_BASE_URL=http://opaal:3333
       - BSS_OAUTH2_PUBLIC_BASE_URL=http://opaal:3333
-      - BSS_IPXE_SERVER=${SYSTEM_NAME}.openchami.cluster
+      - BSS_IPXE_SERVER=${SYSTEM_NAME}.${SYSTEM_DOMAIN}
       - BSS_CHAIN_PROTO=https
     #ports:
     #  - '27778:27778'


### PR DESCRIPTION
Currently, "openchami.cluster" is hard-coded as the cluster domain. It would be useful to be able to customize the domain for cases where DNS names use a custom domain. This PR adds the ability to customize the cluster domain by passing an extra (optional) argument to the `generate-configs.sh` script, e.g.:

```
./generate-configs foobar mydomain.tld
```

The second argument is optional, and not passing it will default the domain to "openchami.cluster". In the command above, the cluster base URL generated would be "foobar.mydomain.tld".

This PR also adds other improvements to the `generate-configs.sh` script like further checks and a more complete usage message.