### PR TITLE
Update recipes to support JWT-backed cloud-init

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -64,6 +64,69 @@ This quickstart makes a few assumptions about the target operating system and is
    ```
 
 
+## cloud-init Server Setup
+
+OpenCHAMI utilizes the cloud-init platform for post-boot configuration.
+A custom cloud-init server container is included with this quickstart Docker Compose setup, but must be populated prior to use.
+
+The cloud-init server provides two API endpoints, described in the sections below.
+Choose the appropriate option for your needs.
+
+### Unprotected Data
+
+#### Setup
+The first endpoint, located at `/cloud-init/`, permits access to all stored data (and should therefore not contain configuration secrets).
+Storing data into this endpoint is accomplished via HTTP POST requests containing JSON-formatted cloud-init configuration details.
+For example:
+```bash
+curl 'https://foobar.openchami.cluster/cloud-init/' \
+    -X POST \
+    -d '{"name": "IDENTIFIER", "cloud-init": {
+        "userdata": {
+            "write_files": [{"content": "hello world", "path": "/etc/hello"}]
+        },
+        "metadata": {...},
+        "vendordata": {...}
+    }}'
+```
+`IDENTIFIER` can be:
+- A node MAC address
+- A node xname
+- An SMD group name
+It may be easiest to add nodes to a group for testing, and upload a cloud-init configuration for that group to this server.
+
+#### Usage
+Data is retrieved via HTTP GET requests to the `meta-data`, `user-data`, and `vendor-data` endpoints.
+For example, one could download all cloud-init data for a node/group via `curl 'https://foobar.openchami.cluster/cloud-init/<IDENTIFIER>/{meta-data,user-data,vendor-data}'`.
+
+When retrieving data, `IDENTIFIER` can also be omitted entirely (e.g. `https://foobar.openchami.cluster/cloud-init/user-data`).
+In this case, the cloud-init server will attempt to look up the relevant xname based on the request's source IP address.
+
+Thus, the intended use case is to set nodes' cloud-init datasource URLs to `https://foobar.openchami.cluster/cloud-init/`, from which the cloud-init client will load its configuration data.
+Note that in this case, no `IDENTIFIER` is provided, so IP-based autodetection will be performed.
+
+### JWT-Protected Data
+
+#### Setup
+The second endpoint, located at `/cloud-init-secure/`, restricts access to its cloud-init data behind a valid bearer token (i.e. a JWT).
+Storing data into this endpoint requires a valid access token, which we assume is stored in `$ACCESS_TOKEN`.
+The workflow described for unprotected data can be used, with the addition of the required authorization header, via e.g. `curl`'s `-H "Authorization: Bearer $ACCESS_TOKEN"`.
+
+#### Usage
+In order to access this protected data, nodes must also supply valid JWTs.
+These may be distributed to nodes at boot time by including [`tpm-manager.yml`](tpm-manager.yml) in the `docker compose` command provided above.
+(It should be provided last, since it supplements service definitions from other files.)
+
+For nodes without hardware TPMs, the TPM manager will drop a JWT into `/var/run/cloud-init-jwt`.
+The token can be retrieved and included with a request to the cloud-init server, using an invocation such as:
+```bash
+curl 'https://foobar.openchami.cluster/cloud-init-secure/<IDENTIFIER>/{meta-data,user-data,vendor-data}' \
+    --create-dirs --output '/PATH/TO/DATA-DIR/#1' \
+    --header "Authorization: Bearer $(</var/run/cloud-init-jwt)"
+```
+cloud-init (i.e. on the node) can then be pointed at `file:///PATH/TO/DATA-DIR/` as its datasource URL.
+
+For nodes *with* hardware TPMs, the token will be dropped into the TPM's secure storage with `ownerread|ownerwrite` scope, and can be retrieved using the `tpm2_nvread` command.
 
 
 ## What's next?

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -40,12 +40,14 @@ frontend openchami
   acl PATH_opaal-idp path_beg -i /oauth2/token
 
   acl PATH_cloud-init path_beg -i /cloud-init
+  acl PATH_cloud-init path_beg -i /cloud-init-secure
 
 
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp
   use_backend smd if PATH_smd
   use_backend bss if PATH_bss
+  use_backend cloud-init if PATH_cloud-init
 
 backend opaal
   server opaal opaal:3333
@@ -60,6 +62,5 @@ backend bss
   server bss bss:27778
   http-request replace-path ^/apis/bss/(.*) /\1
 
-
-
-
+backend cloud-init
+  server cloud-init cloud-init:27777

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -117,7 +117,7 @@ services:
 ###
   # cloud-init server, with the secure route disabled for now
   cloud-init:
-    image: ghcr.io/openchami/cloud-init:v0.1.0
+    image: ghcr.io/openchami/cloud-init:v0.1.1
     container_name: cloud-init
     hostname: cloud-init
     environment:

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -93,6 +93,7 @@ services:
       - BSS_OAUTH2_PUBLIC_BASE_URL=http://opaal:3333
       - BSS_IPXE_SERVER=${SYSTEM_NAME}.${SYSTEM_DOMAIN}
       - BSS_CHAIN_PROTO=https
+      - BSS_BOOTSCRIPT_NOTIFY_URL=http://tpm-manager:27780/Node
     #ports:
     #  - '27778:27778'
     depends_on:

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -112,5 +112,24 @@ services:
       interval: 5s
       timeout: 10s
       retries: 60
-
-
+###
+# cloud-init Server Container
+###
+  # cloud-init server, with the secure route disabled for now
+  cloud-init:
+    image: ghcr.io/openchami/cloud-init:v0.1.0
+    container_name: cloud-init
+    hostname: cloud-init
+    environment:
+      - LISTEN_ADDR=:27777
+      - SMD_URL=http://smd:27779
+      - OPAAL_URL=http://opaal:3333
+    ports:
+      - '27777:27777'
+    depends_on:
+      smd:
+        condition: service_healthy
+      opaal:
+        condition: service_healthy
+    networks:
+      - internal

--- a/quickstart/tpm-manager.yml
+++ b/quickstart/tpm-manager.yml
@@ -11,6 +11,10 @@ services:
       - OPAAL_URL=http://opaal:3333
       - HSM_URL=http://smd:27779
       - ANSIBLE_HOST_KEY_CHECKING=False
+    volumes:
+      - type: bind
+        source: /root/.ssh
+        target: /root/.ssh
     depends_on:
       opaal:
         condition: service_healthy

--- a/quickstart/tpm-manager.yml
+++ b/quickstart/tpm-manager.yml
@@ -18,3 +18,11 @@ services:
         condition: service_healthy
     networks:
       - internal
+  ###
+  # cloud-init server container, provides secured config access via JWT authorization
+  # NOTE: This merges with the default cloud-init config specified in openchami-svcs.yml
+  ###
+  cloud-init:
+    environment:
+      # This enables the server's secure route
+      - JWKS_URL=http://opaal:3333/keys

--- a/quickstart/tpm-manager.yml
+++ b/quickstart/tpm-manager.yml
@@ -3,7 +3,7 @@ services:
   # TPM-manager container, pushes cloud-init tokens into nodes' TPM storage
   ###
   tpm-manager:
-    image: ghcr.io/openchami/tpm-manager:v0.1.3
+    image: ghcr.io/openchami/tpm-manager:v0.2.2
     container_name: tpm-manager
     hostname: tpm-manager
     command: ["-port", "27780", "-batch-size", "100", "-interval", "30s"]

--- a/quickstart/tpm-manager.yml
+++ b/quickstart/tpm-manager.yml
@@ -1,0 +1,20 @@
+services:
+  ###
+  # TPM-manager container, pushes cloud-init tokens into nodes' TPM storage
+  ###
+  tpm-manager:
+    image: ghcr.io/openchami/tpm-manager:v0.1.3
+    container_name: tpm-manager
+    hostname: tpm-manager
+    command: ["-port", "27780", "-batch-size", "100", "-interval", "30s"]
+    environment:
+      - OPAAL_URL=http://opaal:3333
+      - HSM_URL=http://smd:27779
+      - ANSIBLE_HOST_KEY_CHECKING=False
+    depends_on:
+      opaal:
+        condition: service_healthy
+      smd:
+        condition: service_healthy
+    networks:
+      - internal


### PR DESCRIPTION
## Added
- Initial TPM-manager container
- Optional extra YAML file (for Docker Compose) to incorporate TPM manager and enable JWT-backed cloud-init endpoints

## Changed
- New cloud-init server, with support for JWT-backed endpoints
- Minor update to BSS, adding support for notifications (i.e. POSTs to a specified URL; in this case to the TPM manager)

## Related
- OpenCHAMI/cloud-init#10
- OpenCHAMI/bss#36
- OpenCHAMI/cloud-init#11