### PR TITLE
Remove -it from docker commands in quickstart/bash_functions.sh

### DIFF
--- a/quickstart/bash_functions.sh
+++ b/quickstart/bash_functions.sh
@@ -12,13 +12,13 @@ get_eth0_ipv4() {
 
 get_ca_cert() {
     local ca_cert
-    ${CONTAINER_CMD:-docker} exec -it step-ca step ca root
+    ${CONTAINER_CMD:-docker} exec step-ca step ca root
     echo "${ca_cert}"
 }
 
 container_curl() {
     local url=$1
-    ${CONTAINER_CMD:-docker} run -it --rm "${CURL_CONTAINER}:${CURL_TAG}" -s $url
+    ${CONTAINER_CMD:-docker} run --rm "${CURL_CONTAINER}:${CURL_TAG}" -s $url
 }
 
 create_client_credentials() {


### PR DESCRIPTION
Fixes #65

This PR removes `-it` from `docker` commands in quickstart/bash_functions.sh.

The `docker` commands in the quickstart/bash_functions.sh file that use `-it` do not require stdin to be opened (`-i`) nor do they require a TTY to be allocated (`-t`). Having these flags in the commands actually causes issues in non-interactive situations like when running the quickstart steps in CI/CD runners.