### PR TITLE
quickstart: Bump BSS from v1.31.0 to v1.31.2

### DIFF
--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -56,7 +56,7 @@ services:
 ###
 # sets up postgres for BSS data
   bss-init:
-    image: ghcr.io/openchami/bss:v1.31.0
+    image: ghcr.io/openchami/bss:v1.31.2
     container_name: bss-init
     hostname: bss-init
     environment:
@@ -76,7 +76,7 @@ services:
       - /usr/local/bin/bss-init
   # boot-script-service
   bss:
-    image: ghcr.io/openchami/bss:v1.31.0
+    image: ghcr.io/openchami/bss:v1.31.2
     container_name: bss
     hostname: bss
     environment:


### PR DESCRIPTION
This BSS update introduces fixes that allow all endpoints to work with a PostgreSQL storage backend, which is the default in the quickstart.