### PR TITLE
Bump BSS and SMD to versions using OpenCHAMI middleware

### DIFF
--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -4,7 +4,7 @@ services:
 ###
   # sets up postgres for SMD data
   smd-init:
-    image: ghcr.io/openchami/smd:v2.15.2
+    image: ghcr.io/openchami/smd:v2.15.3
     container_name: smd-init
     hostname: smd-init
     environment:
@@ -23,7 +23,7 @@ services:
       - /smd-init
   # SMD
   smd:
-    image: ghcr.io/openchami/smd:v2.15.2
+    image: ghcr.io/openchami/smd:v2.15.3
     container_name: smd
     hostname: smd
     environment:

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -56,7 +56,7 @@ services:
 ###
 # sets up postgres for BSS data
   bss-init:
-    image: ghcr.io/openchami/bss:v1.31.2
+    image: ghcr.io/openchami/bss:v1.31.3
     container_name: bss-init
     hostname: bss-init
     environment:
@@ -76,7 +76,7 @@ services:
       - /usr/local/bin/bss-init
   # boot-script-service
   bss:
-    image: ghcr.io/openchami/bss:v1.31.2
+    image: ghcr.io/openchami/bss:v1.31.3
     container_name: bss
     hostname: bss
     environment:


### PR DESCRIPTION
- Integrates https://github.com/OpenCHAMI/bss/pull/47
- Integrates https://github.com/OpenCHAMI/smd/pull/29

Bump BSS and SMD versions:
- SMD: v2.15.2 -> v2.15.3
- BSS: v1.31.2 -> v1.31.3

These versions use the OpenCHAMI logging and authentication [middleware](https://github.com/OpenCHAMI/chi-middleware).