### PR TITLE
quickstart: Bump SMD from v2.15.3 to v2.16.0

### DIFF
--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -4,7 +4,7 @@ services:
 ###
   # sets up postgres for SMD data
   smd-init:
-    image: ghcr.io/openchami/smd:v2.15.3
+    image: ghcr.io/openchami/smd:v2.16.0
     container_name: smd-init
     hostname: smd-init
     environment:
@@ -23,7 +23,7 @@ services:
       - /smd-init
   # SMD
   smd:
-    image: ghcr.io/openchami/smd:v2.15.3
+    image: ghcr.io/openchami/smd:v2.16.0
     container_name: smd
     hostname: smd
     environment:


### PR DESCRIPTION
SMD v2.16.0 uses the new parsing code introduced in https://github.com/OpenCHAMI/smd/pull/30