### PR TITLE
chore: correct swiss-army-knife image repo

### DIFF
--- a/lbnl/helm/values.yaml
+++ b/lbnl/helm/values.yaml
@@ -164,7 +164,7 @@ swiss_army_knife:
   deployment:
     replicaCount: 1
     image:
-      repository: hub.docker.io/leodotcloud
+      repository: docker.io/leodotcloud
       name: swiss-army-knife
       pullPolicy: IfNotPresent
       tag: latest


### PR DESCRIPTION
Docker Hub apparently no longer recognizes the hub subdomain, and the earlier default resulted in an ImagePullBackOff. This changes the swiss-army-knife repo to "docker.io/leodotcloud", which does work.

After `helm install` from current main (2fd885a8c3922a4301d0ad49ba1df51883d39c62):

```
$ kubectl describe po swiss-army-knife-589f5cb769-rhl74 | grep Warning
  Warning  Failed     25s (x2 over 38s)  kubelet            Failed to pull image "hub.docker.io/leodotcloud/swiss-army-knife:latest": failed to pull and unpack image "hub.docker.io/leodotcloud/swiss-army-knife:latest": failed to resolve reference "hub.docker.io/leodotcloud/swiss-army-knife:latest": failed to do request: Head "https://hub.docker.io/v2/leodotcloud/swiss-army-knife/manifests/latest": dial tcp: lookup hub.docker.io on 172.18.0.1:53: no such host
  Warning  Failed     25s (x2 over 38s)  kubelet            Error: ErrImagePull
  Warning  Failed     10s (x2 over 38s)  kubelet            Error: ImagePullBackOff