### PR TITLE
chore: only provision BackendConfig if available

### DIFF
--- a/lbnl/helm/templates/krakend/backendconfig.yaml
+++ b/lbnl/helm/templates/krakend/backendconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "cloud.google.com/v1" }}
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
@@ -12,3 +13,4 @@ spec:
     requestPath: /__health
   securityPolicy:
     name: {{ default "" .Values.gke.securityPolicy }}
+{{- end }}

--- a/lbnl/helm/templates/lighttpd/backendconfig.yaml
+++ b/lbnl/helm/templates/lighttpd/backendconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "cloud.google.com/v1" }}
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
@@ -12,3 +13,4 @@ spec:
     requestPath: /foo
   securityPolicy:
     name: {{ default "" .Values.gke.securityPolicy }}
+{{- end }}


### PR DESCRIPTION
Add `.Capablities` checks for the cloud.google.com/v1 group to the lighttpd and krakend BackendConfig resources. This CRD is only available on GKE and blocks install on other cluster types otherwise.

Caveats:
* This does not add any generic equivalent of the configuration in the BackendConfigs.
* These checks may not be  supported on all CD Helm integrations.

More on these after the jump.

---

**No generic replacement**

This particular resource appears like it'd only be useful on GKE. The generic equivalent of the healthcheck is the Pod template readiness or liveness check. krakend already uses an equivalent readiness check, but lighttp uses a command-based readiness check instead.

Some [features of BackendConfig](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#configuring_ingress_features_through_backendconfig_parameters) may be available in GWAPI configuration, but those configuration parameters will almost always be in Extended support, and won't be available across all GWAPI implementations.

GWAPI does not provide an healthcheck feature specific to individual Route resources AFAIK.

As an example of something that _is_ available via both BackendConfig and GWAPI, https://gateway-api.sigs.k8s.io/geps/gep-1742 does appear to be in the released GWAPI APIs (based on https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteTimeouts). We're not setting timeouts though, so I don't think there's any reason to add that or other Extended configuration to the HTTPRoutes yet.

**CD integrations do not support standard Helm features that require API server communication**

`.Capabilities` checks (and anything that involves talking to the Kubernetes API server, such as `lookup`) historically have not played nicely with CD Helm integrations that invoke `helm template` instead of `helm install`. Some CD applications have partial workarounds for this.

IIRC ArgoCD does a decent job of handling its own `.Capabilities`-style lookups and passing `--api-versions` to `helm template`. I don't recall other CD solutions that do, but I have less experience with them. I didn't find good info for FluxCD on a cursory search.

https://github.com/helm/helm/pull/9426 maybe allows CD systems that use `helm template` (somewhat confusingly, you can use `--dry-run` with `helm template`, and IIRC the server communication works as expected with it--I recall playing with it a while ago). However, I haven't reviewed adoption of this feature across CD solutions. Some have feature issues linked to that Helm issue.