### PR TITLE
Quadlet recipe update

### DIFF
--- a/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
@@ -270,6 +270,7 @@ _ochami_quadlets:
       - BSS_OAUTH2_PUBLIC_BASE_URL=http://opaal:3333
       - 'BSS_IPXE_SERVER={{ cluster_name }}.{{ cluster_domain }}'
       - BSS_CHAIN_PROTO=https
+      - BSS_BOOTSCRIPT_NOTIFY_URL=http://tpm-manager:27780/Node
     after:
       - bss-init.service
       - opaal.service
@@ -282,8 +283,6 @@ _ochami_quadlets:
       - SMD_URL=http://smd:27779
       - OPAAL_URL=http://opaal:3333
       - JWKS_URL=http://opaal:3333/keys
-    ports:
-      - '{{cluster_boot_ip }}:27777:27777'
     after:
       - smd.service
       - opaal.service
@@ -301,6 +300,9 @@ _ochami_quadlets:
       - opaal.service
     networks:
       - ochami-internal.network
+      - ochami-external.network
+    volumes:
+      - /root/.ssh:/root/.ssh:ro
 
 _haproxy_quadlets:
   - name: haproxy

--- a/lanl/podman-quadlets/roles/auth/handlers/main.yaml
+++ b/lanl/podman-quadlets/roles/auth/handlers/main.yaml
@@ -1,8 +1,4 @@
 ---
 - name: distrust ochami certificate
   become: true
-  ansible.builtin.shell: 'trust anchor --remove /tmp/ochami.pem; update-ca-trust'
-
-- name: delete ochami certificate
-  become: true
-  ansible.builtin.command: 'rm -f /tmp/ochami.pem'
+  ansible.builtin.shell: 'rm -f /etc/pki/ca-trust/source/anchors/ochami_tmp.pem; update-ca-trust'

--- a/lanl/podman-quadlets/roles/auth/tasks/main.yaml
+++ b/lanl/podman-quadlets/roles/auth/tasks/main.yaml
@@ -1,10 +1,9 @@
 ---
 - name: get ochami certificate
-  ansible.builtin.shell: '/bin/bash -l -c "get_ca_cert > /tmp/ochami.pem"'
-  notify: delete ochami certificate
+  ansible.builtin.shell: '/bin/bash -l -c "get_ca_cert > /etc/pki/ca-trust/source/anchors/ochami_tmp.pem"'
 
 - name: trust ochami certificate
-  ansible.builtin.shell: 'trust anchor --store /tmp/ochami.pem && update-ca-trust'
+  ansible.builtin.shell: 'update-ca-trust'
   notify: distrust ochami certificate
 
 - name: obtain access token to write to smd


### PR DESCRIPTION
1. Added ENV variable to BSS so that is notifies tpm-manager when a node is booting. 

2. Also updated the auth role so that it works with existing ca certs. 

The current method only works if there isn't an existing cert...
```bash
#Run Previously by an admin at some point
get_ca_cert > /etc/pki/ca-trust/source/anchors/ochami.pem
update-ca-trust

#Run as part of the current auth role
/bin/bash -l -c "get_ca_cert > /tmp/ochami.pem"
trust anchor --store /tmp/ochami.pem && update-ca-trust
```

The last command results in 
```
p11-kit: couldn't create object: The field is read-only
p11-kit: 1 error while processing
```

This change switches from the current `trust anchor ...` commands to essentially
```bash
/bin/bash -l -c "get_ca_cert > /etc/pki/ca-trust/source/anchors/ochami_tmp.pem"
update-ca-trust
```
