### PR TITLE
fix: correct coresmd container to be coredhcp, bump version

### DIFF
--- a/quickstart/coredhcp.yml
+++ b/quickstart/coredhcp.yml
@@ -1,6 +1,6 @@
 services:
   coredhcp:
-    image: ghcr.io/openchami/coresmd:v0.0.5
+    image: ghcr.io/openchami/coredhcp:v0.0.6
     container_name: coredhcp
     hostname: coredhcp
     network_mode: host


### PR DESCRIPTION
Addresses [this comment](https://github.com/OpenCHAMI/deployment-recipes/issues/86#issuecomment-2465394457).

Fix the name of the container from the old `coresmd` to the new `coredhcp`. Also, bump the version to v0.0.6 to include a coresmd container fix that eliminates 'permission denied' errors when attempting to bind to port 67.