### PR TITLE
feat(quickstart): add configurator to haproxy

### DIFF
--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -42,12 +42,15 @@ frontend openchami
   acl PATH_cloud-init path_beg -i /cloud-init
   acl PATH_cloud-init path_beg -i /cloud-init-secure
 
+  acl PATH_configurator path_beg -i /generate
+
 
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp
   use_backend smd if PATH_smd
   use_backend bss if PATH_bss
   use_backend cloud-init if PATH_cloud-init
+  use_backend configurator if PATH_configurator
 
 backend opaal
   server opaal opaal:3333
@@ -64,3 +67,6 @@ backend bss
 
 backend cloud-init
   server cloud-init cloud-init:27777
+
+backend configurator
+  server configurator configurator:3334


### PR DESCRIPTION
Add a path in the API gateway for communicating with the configurator service in the quickstart.