### PR TITLE
lanl/podman-quadlets: Update SMD and replace ochami-cli with ochami in Ansible

### DIFF
--- a/lanl/podman-quadlets/inventory/group_vars/ochami/bss.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/bss.yaml
@@ -9,6 +9,6 @@ bss_params: '{{ bss_params_root }} {{ bss_params_cloud_init }} {{ bss_params_opt
 
 _bss_macs: |
         {% for item in nodes %}
-        - {{ item.mac }}
+        - {{ item.interfaces[0].mac_addr }}
         {% endfor %}
 bss_macs: "{{ _bss_macs | from_yaml }}"

--- a/lanl/podman-quadlets/inventory/group_vars/ochami/nodes.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/nodes.yaml
@@ -1,9 +1,12 @@
 nodes:
-  - bmc_ipaddr: 172.16.0.101
-    ipaddr: 172.16.0.1
-    mac: dc:d7:a3:05:f7:ae
-    nid: 1
-    xname: x1000c1s7b0n0
-    group: compute
-    name: nid01
-
+- name: nid001
+  xname: x1000c1s7b1n0
+  nid: 1
+  group: compute
+  bmc_mac: c2:77:05:e2:03:48
+  bmc_ip: 172.16.0.101
+  interfaces:
+  - mac_addr: ec:e7:a7:05:a1:fc
+    ip_addrs:
+    - name: management
+      ip_addr: 172.16.0.1

--- a/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
@@ -201,7 +201,7 @@ _opaal_quadlets:
 
 _ochami_quadlets:
   - name: smd-init
-    image: ghcr.io/openchami/smd:v2.16.1
+    image: ghcr.io/openchami/smd:v2.17.7
     secrets:
       - smd_postgres_password,type=env,target=SMD_DBPASS
     envs:
@@ -218,7 +218,7 @@ _ochami_quadlets:
     restart: 'on-failure'
     type: 'oneshot'
   - name: smd
-    image: ghcr.io/openchami/smd:v2.16.1
+    image: ghcr.io/openchami/smd:v2.17.7
     secrets:
       - smd_postgres_password,type=env,target=SMD_DBPASS
     envs:

--- a/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
+++ b/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
@@ -1,11 +1,14 @@
+- name: Get ochami latest release URL
+  ansible.builtin.shell: |
+    curl -s https://api.github.com/repos/OpenCHAMI/ochami/releases/latest | jq -r '.assets[] | select(.name | endswith("amd64.rpm")) | .browser_download_url'
+  register: ochami_latest_release_url
+
 - name: Drop ochami nodes.yaml
   ansible.builtin.template:
     src: ochami/nodes.yaml.j2
     dest: /etc/ochami/nodes.yaml
 
-- name: get ochami-cmdline
-  ansible.builtin.git:
-    repo: https://github.com/OpenCHAMI/ochami-cmdline.git
-    dest: /opt/ochami/bin/
-    update: no
-    version: main
+- name: get ochami CLI
+  ansible.builtin.dnf:
+    name: '{{ ochami_latest_release_url.stdout }}'
+    state: present

--- a/lanl/podman-quadlets/roles/smd/tasks/main.yaml
+++ b/lanl/podman-quadlets/roles/smd/tasks/main.yaml
@@ -1,13 +1,12 @@
 # Using this monstrosity until we can figure out a way to speed up an ansible way of populating SMD
-- name: Populate SMD with ochami-cli
+- name: Populate SMD with ochami CLI
   ansible.builtin.command:
     argv:
-      - /opt/ochami/bin/ochami-cli
-      - --access-token
+      - /usr/local/bin/ochami
+      - --token
       - "{{ access_token.stdout }}"
-      - --smd-url
-      - "{{ ochami_smd_url }}"
-      - smd
-      - --fake-discovery
+      - discover
       - --payload
       - "/etc/ochami/nodes.yaml"
+      - --payload-format
+      - yaml


### PR DESCRIPTION
These changes are in conjunction with https://github.com/OpenCHAMI/mini-bootcamp/pull/2.