### PR TITLE
fix(lanl-quadlets): ochami CLI installation/configuration

### DIFF
--- a/lanl/podman-quadlets/roles/configs/defaults/main.yaml
+++ b/lanl/podman-quadlets/roles/configs/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+ochami_cli_log_level: warning
+ochami_cli_log_format: basic

--- a/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
+++ b/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
@@ -12,3 +12,4 @@
   ansible.builtin.dnf:
     name: '{{ ochami_latest_release_url.stdout }}'
     state: present
+    disable_gpg_check: true

--- a/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
+++ b/lanl/podman-quadlets/roles/configs/tasks/ochami.yaml
@@ -13,3 +13,8 @@
     name: '{{ ochami_latest_release_url.stdout }}'
     state: present
     disable_gpg_check: true
+
+- name: configure ochami CLI
+  ansible.builtin.template:
+    src: ochami/config.yaml.j2
+    dest: /etc/ochami/config.yaml

--- a/lanl/podman-quadlets/roles/configs/templates/ochami/config.yaml.j2
+++ b/lanl/podman-quadlets/roles/configs/templates/ochami/config.yaml.j2
@@ -1,0 +1,8 @@
+clusters:
+  - cluster:
+      base-uri: {{ ochami_base_url }}
+    name: {{ cluster_name }}
+default-cluster: {{ cluster_name }}
+log:
+  format: {{ ochami_cli_log_format }}
+  level: {{ ochami_cli_log_level }}

--- a/lanl/podman-quadlets/roles/smd/tasks/main.yaml
+++ b/lanl/podman-quadlets/roles/smd/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Populate SMD with ochami CLI
   ansible.builtin.command:
     argv:
-      - /usr/local/bin/ochami
+      - /usr/bin/ochami
       - --token
       - "{{ access_token.stdout }}"
       - discover


### PR DESCRIPTION
- Don't attempt to verify RPM signature on unsigned RPM
- Provide system-wide config file
- Correct binary path (newest RPM places binary into /usr/bin instead of /usr/local/bin)