### PR TITLE
Quickstart: add healthcheck to configurator and update config

### DIFF
--- a/quickstart/configs/configurator.yaml
+++ b/quickstart/configs/configurator.yaml
@@ -1,13 +1,15 @@
-server:         # Server-related parameters when using as service
-  host: 0.0.0.0
-  port: 3334
-  jwks:         # Set the JWKS uri to protect /generate route
+# Server-related parameters when using as service
+server:
+  host: 0.0.0.0:3334
+  # Set the JWKS uri to protect /generate route
+  jwks:
     uri: ""
     retries: 5
-smd:          # SMD-related parameters
-  host: http://smd
-  port: 27779
-targets:        # targets to call with --target flag with CLI or "target" query param
+# SMD-related parameters
+smd:
+  host: http://smd:27779
+# targets to call with --target flag with CLI or "target" query param
+targets:
   coredhcp: 
     templates: 
       - templates/coredhcp.jinja

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -66,7 +66,7 @@ backend bss
   http-request replace-path ^/apis/bss/(.*) /\1
 
 backend cloud-init
-  server cloud-init-server cloud-init-server:27777
+  server cloud-init-server cloud-init:27777
 
 backend configurator
   server configurator configurator:3334

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -43,7 +43,7 @@ frontend openchami
   acl PATH_cloud-init path_beg -i /cloud-init-secure
 
   acl PATH_configurator path_beg -i /generate
-
+  acl PATH_configurator path_beg -i /configurator
 
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp
@@ -66,7 +66,7 @@ backend bss
   http-request replace-path ^/apis/bss/(.*) /\1
 
 backend cloud-init
-  server cloud-init cloud-init:27777
+  server cloud-init-server cloud-init-server:27777
 
 backend configurator
   server configurator configurator:3334

--- a/quickstart/configurator.yml
+++ b/quickstart/configurator.yml
@@ -8,6 +8,7 @@ services:
       - 'serve'
       - '--config'
       - '/configurator/config.yaml'
+      - '--verbose'
     volumes:
       - ./configs/configurator.yaml:/configurator/config.yaml
     networks:

--- a/quickstart/configurator.yml
+++ b/quickstart/configurator.yml
@@ -14,9 +14,8 @@ services:
       - internal
     ports:
       - 3334:3334
-    # NOTE: configurator does not have a /status endpoint yet
-    # healthcheck:
-    #   test: ["CMD", "curl", "--fail", "--silent", "http://localhost:3334/status"]
-    #   interval: 5s
-    #   timeout: 10s
-    #   retries: 60
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:3334/configurator/status"]
+      interval: 5s
+      timeout: 10s
+      retries: 60


### PR DESCRIPTION
Version 0.2.1 of configurator implements the `configurator/status` healthcheck endpoint, so use that in the docker compose recipe.

Also, update the configurator config file to correct the indentation and remove the `port` directive (this should now be appended to the `host` parameter with a colon, if needed).