### PR TITLE
feat(quickstart): add pcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 lanl/docker-compose/configs/step-ca/*
 lbnl/helm/charts/
 **/*.pem
+quickstart/policy.yml

--- a/quickstart/.gitignore
+++ b/quickstart/.gitignore
@@ -1,0 +1,1 @@
+access_token

--- a/quickstart/.gitignore
+++ b/quickstart/.gitignore
@@ -1,1 +1,2 @@
 access_token
+keys

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -1,5 +1,8 @@
-run:
+run: keys
 	bash run.sh
+
+keys:
+	bash create-keys.sh
 
 check:
 	bash check.sh

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -1,0 +1,11 @@
+run:
+	bash run.sh
+
+check:
+	bash check.sh
+
+test:
+	bash test-request-on-smd.sh
+
+stop:
+	bash stop.sh

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -10,5 +10,8 @@ check:
 test:
 	bash test-request-on-smd.sh
 
+clean: stop
+	bash clean.sh
+
 stop:
 	bash stop.sh

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -1,3 +1,5 @@
+re: clean run
+
 run: keys
 	bash run.sh
 

--- a/quickstart/check.sh
+++ b/quickstart/check.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "check the if pcs is running"
+
+docker logs pcs 2>&1 | grep '**RUNNING -- Listening'
+docker logs pcs 2>&1 | grep 'ETCD connection succeeded.'

--- a/quickstart/clean.sh
+++ b/quickstart/clean.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+rm -rf keys
+
 docker volume rm \
 $( \
 docker volume ls \

--- a/quickstart/clean.sh
+++ b/quickstart/clean.sh
@@ -4,4 +4,4 @@ rm -rf keys
 
 VOLUME=$(docker volume ls --format "{{.Name}}" --filter "name=quickstart")
 
-if [[ -z VOLUME ]]; then docker volume rm $VOLUME; fi
+if [ -n "${VOLUME}" ]; then docker volume rm "${VOLUME}"; fi

--- a/quickstart/clean.sh
+++ b/quickstart/clean.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker volume rm \
+$( \
+docker volume ls \
+--format "{{.Name}}" \
+--filter "name=quickstart"\
+)

--- a/quickstart/clean.sh
+++ b/quickstart/clean.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 rm -rf keys
 
-VOLUME=$(docker volume ls --format "{{.Name}}" --filter "name=quickstart")
+VOLUME=($(docker volume ls --format "{{.Name}}" --filter "name=quickstart"))
 
-if [ -n "${VOLUME}" ]; then docker volume rm "${VOLUME}"; fi
+if [ -n "${VOLUME}" ]; then docker volume rm "${VOLUME[@]}"; fi

--- a/quickstart/clean.sh
+++ b/quickstart/clean.sh
@@ -2,9 +2,6 @@
 
 rm -rf keys
 
-docker volume rm \
-$( \
-docker volume ls \
---format "{{.Name}}" \
---filter "name=quickstart"\
-)
+VOLUME=$(docker volume ls --format "{{.Name}}" --filter "name=quickstart")
+
+if [[ -z VOLUME ]]; then docker volume rm $VOLUME; fi

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -1,11 +1,12 @@
 global
   stats socket /var/run/api.sock user haproxy group haproxy mode 660 level admin expose-fd listeners
-  log stdout format raw local0 info
+  log stdout local0 info
   fd-hard-limit 50000
   ssl-default-bind-options ssl-min-ver TLSv1.3 no-tls-tickets
 
 defaults
   mode http
+  option httplog
   timeout client 10s
   timeout connect 5s
   timeout server 10s
@@ -45,12 +46,13 @@ frontend openchami
   acl PATH_configurator path_beg -i /generate
   acl PATH_configurator path_beg -i /configurator
 
-  acl PATH_pcs path_beg -i /transitions
-  acl PATH_pcs path_beg -i /power-status
-  acl PATH_pcs path_beg -i /power-cap
-  acl PATH_pcs path_beg -i /liveness
-  acl PATH_pcs path_beg -i /readiness
-  acl PATH_pcs path_beg -i /health
+  acl PATH_pcs path_beg -i /power-control/v1
+  # acl PATH_pcs path_beg -i /transitions
+  # acl PATH_pcs path_beg -i /power-status
+  # acl PATH_pcs path_beg -i /power-cap
+  # acl PATH_pcs path_beg -i /liveness
+  # acl PATH_pcs path_beg -i /readiness
+  # acl PATH_pcs path_beg -i /health
 
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp
@@ -62,6 +64,7 @@ frontend openchami
 
 backend pcs
   server pcs pcs:28007
+  http-request replace-path ^/power-control/(.*) /\1
 
 backend opaal
   server opaal opaal:3333

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -45,9 +45,12 @@ frontend openchami
   acl PATH_configurator path_beg -i /generate
   acl PATH_configurator path_beg -i /configurator
 
-  acl PATH_pcs path_beg -i /health
+  acl PATH_pcs path_beg -i /transitions
+  acl PATH_pcs path_beg -i /power-status
+  acl PATH_pcs path_beg -i /power-cap
   acl PATH_pcs path_beg -i /liveness
   acl PATH_pcs path_beg -i /readiness
+  acl PATH_pcs path_beg -i /health
 
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp

--- a/quickstart/configs/haproxy.cfg
+++ b/quickstart/configs/haproxy.cfg
@@ -45,12 +45,20 @@ frontend openchami
   acl PATH_configurator path_beg -i /generate
   acl PATH_configurator path_beg -i /configurator
 
+  acl PATH_pcs path_beg -i /health
+  acl PATH_pcs path_beg -i /liveness
+  acl PATH_pcs path_beg -i /readiness
+
   use_backend opaal if PATH_opaal
   use_backend opaal-idp if PATH_opaal-idp
   use_backend smd if PATH_smd
   use_backend bss if PATH_bss
   use_backend cloud-init if PATH_cloud-init
   use_backend configurator if PATH_configurator
+  use_backend pcs if PATH_pcs
+
+backend pcs
+  server pcs pcs:28007
 
 backend opaal
   server opaal opaal:3333

--- a/quickstart/create-keys.sh
+++ b/quickstart/create-keys.sh
@@ -57,10 +57,15 @@ create_token() {
 	)
 }
 
+create_role() {
+	echo "test-role" > "${KEYS_PATH}"/role
+}
+
 main() {
 	mkdir -p "${KEYS_PATH}"
 	create_keys
 	create_token
+	create_role
 }
 
 main

--- a/quickstart/create-keys.sh
+++ b/quickstart/create-keys.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+KEYS_PATH="keys"
+
+create_keys() {
+	(
+	cd "${KEYS_PATH}"
+	openssl genrsa -out private_key.pem 2048
+	openssl rsa -in private_key.pem -outform PEM -pubout -out public_key.pem
+	)
+}
+
+create_token() {
+	(
+	cd "${KEYS_PATH}"
+	cipher="RS256"
+	pub_key="private_key.pem"
+
+	header="$(cat <<-EOF
+	{
+	  "alg": "$cipher",
+	  "typ": "JWT",
+	  "kid": "$kid"
+	}
+	EOF
+	)"
+
+	payload="$(cat <<-EOF
+	{
+	  "aud": "test",
+	  "name": "John Doe",
+	  "iat" : $(date +%s),
+	  "exp": $(date +%s --date tomorrow),
+	  "sub": "sub"
+	}
+	EOF
+	)"
+
+	header=$(jq -c -r . <<< "$header")
+
+	header=$(echo -n "$header" | \
+		openssl enc -base64 \
+		| tr -d '=' | tr '/+' '_-' | tr -d '\n' )
+
+	payload=$(jq -c -r . <<< "$payload" 2>&1);
+
+	payload=$(echo -n "$payload" | \
+		openssl enc -base64 | \
+		tr -d '=' | tr '/+' '_-' | tr -d '\n' )
+
+	signature="$(echo -n "${header}.${payload}" | \
+		openssl dgst -sha256 -binary -sign ${pub_key} | \
+		openssl enc -base64 | \
+		tr -d '=' | tr '/+' '_-' | tr -d '\n' )"
+
+	echo "${header}.${payload}.$signature" > token
+	)
+}
+
+main() {
+	mkdir -p "${KEYS_PATH}"
+	create_keys
+	create_token
+}
+
+main

--- a/quickstart/etcd.yml
+++ b/quickstart/etcd.yml
@@ -1,5 +1,6 @@
 services:
   etcd:
+    container_name: etcd
     image: quay.io/coreos/etcd:v3.5.17
     environment:
       - ETCD_UNSUPPORTED_ARCH=arm64

--- a/quickstart/etcd.yml
+++ b/quickstart/etcd.yml
@@ -1,0 +1,11 @@
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.5.17
+    environment:
+      - ETCD_UNSUPPORTED_ARCH=arm64
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+    networks:
+      - internal
+      - jwt-internal

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -99,3 +99,19 @@ ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
 No server is available to handle this request.
 </body></html>
 ----
+
+== retry
+
+----
+ochami pcs status
+{"pcs":"ready"}
+manta power off nodes --assume-yes x1000c0s0b3
+INFO  | Create PCS transition 'force-off' on []
+ERROR - Could not power off node/s '[]'. Reason:
+ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
+No server is available to handle this request.
+</body></html>
+
+manta --version
+manta 1.54.1-beta.100
+----

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -1,0 +1,44 @@
+= PCS integration in quickstart
+
+== Interact with PCS through cURL
+
+A list of differents tests.
+
+[source, shell]
+----
+docker exec power-control-smd-1 curl -s power-control-power-control-1:28007/v1/
+<a href="//power-control-power-control-1:28007/v1">Moved Permanently</a>.
+----
+
+[source, shell]
+----
+docker exec power-control-smd-1 curl -s power-control-power-control-1:28007/
+hms-power-control
+----
+
+[source, shell]
+----
+docker exec power-control-smd-1 curl -s power-control-power-control-1:28007/liveness
+----
+
+[source, shell]
+----
+docker exec power-control-smd-1 curl -s power-control-power-control-1:28007/notfound
+404 page not found
+----
+
+From `./internal/hsm/state_manager.go` of `power-control` repository:
+
+[source, go]
+----
+hsmLivenessPath                   = "/hsm/v2/service/liveness"
+hsmStateComponentsPath            = "/hsm/v2/State/Components"
+hsmStateComponentsQueryPath       = "/hsm/v2/State/Components/Query"
+hsmInventoryComponentEndpointPath = "/hsm/v2/Inventory/ComponentEndpoints"
+hsmReservationCheckPath           = "/hsm/v2/locks/service/reservations/check"
+hsmReservationPath                = "/hsm/v2/locks/service/reservations"
+hsmReservationReleasePath         = "/hsm/v2/locks/service/reservations/release"
+hsmPowerMapPath                   = "/hsm/v2/sysinfo/powermaps"
+----
+
+I cannot use these routes.

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -1,6 +1,10 @@
 = PCS integration in quickstart
+:toc:
+:sectnums:
 
 == Interact with PCS through cURL
+
+From this docker compose https://github.com/OpenCHAMI/power-control/blob/main/docker-compose.test.ct.yaml[docker-compose.test.ct.yaml]
 
 A list of differents tests.
 
@@ -42,3 +46,37 @@ hsmPowerMapPath                   = "/hsm/v2/sysinfo/powermaps"
 ----
 
 I cannot use these routes.
+
+== Interact with PCS through Manta cli and cURL
+
+From this quickstart folder.
+
+Manta cli
+
+----
+manta power off nodes --assume-yes x1000c0s0b3
+ERROR - Could not power off node/s '[]'. Reason:
+ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
+No server is available to handle this request.
+</body></html>
+----
+
+curl
+
+----
+docker exec smd curl -s http://pcs:28007/health | jq
+{
+  "KvStore": "connected, responsive",
+  "DistLocking": "connected, responsive",
+  "StateManager": "connected, responsive",
+  "Vault": "connected, responsive",
+  "TaskRunner": "connected, responsive, local mode"
+}
+----
+
+ochami
+
+----
+ochami pcs status
+2025-03-31T15:54:32+02:00 FTL pcs-status.go:55 > PCS status (readiness) request yielded unsuccessful HTTP response error="GetReadiness(): error getting PCS liveness: unsuccessful HTTP status: HTTP/1.1 503 Service Unavailable: <html><body><h1>503 Service Unavailable</h1>\nNo server is available to handle this request.\n</body></html>\n"
+----

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -2,6 +2,21 @@
 :toc:
 :sectnums:
 
+== Step
+
+. Deploy sushy-emulator
+. Create a virtual node
+. Do a `make run` that will
+** generate keys folder
+** start openchami services
+** create access token to openchami service
+** configure vault for jwt authentification
+** populate vault with virtual node url
+
+. with manta:
+.. Add a redfish-endpoint
+.. Add a node in a group
+
 == Interact with PCS through cURL
 
 From this docker compose https://github.com/OpenCHAMI/power-control/blob/main/docker-compose.test.ct.yaml[docker-compose.test.ct.yaml]

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -80,3 +80,22 @@ ochami
 ochami pcs status
 2025-03-31T15:54:32+02:00 FTL pcs-status.go:55 > PCS status (readiness) request yielded unsuccessful HTTP response error="GetReadiness(): error getting PCS liveness: unsuccessful HTTP status: HTTP/1.1 503 Service Unavailable: <html><body><h1>503 Service Unavailable</h1>\nNo server is available to handle this request.\n</body></html>\n"
 ----
+
+== Edit the HAProxy and retry
+
+retry
+
+* ochami works
++
+----
+ochami pcs status
+{"pcs":"ready"}
+----
+
+* manta cli still not working
++
+----
+ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
+No server is available to handle this request.
+</body></html>
+----

--- a/quickstart/exploration-integrate-pcs.adoc
+++ b/quickstart/exploration-integrate-pcs.adoc
@@ -115,3 +115,188 @@ No server is available to handle this request.
 manta --version
 manta 1.54.1-beta.100
 ----
+
+== Manta CLI can talk to PCS
+
+=== Update Manta CLI
+
+. In `eth-cscs/manta`: Switch to local ochami-rs
++
+[source, patch]
+----
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -32,13 +32,13 @@ publish = false                                                         # cargo
+ # PROD
+
+ backend-dispatcher = "0.1.42"
+-ochami-rs = "0.1.44"
++# ochami-rs = "0.1.44"
+ mesa = "0.42.3-beta.75"
+
+ # DEV
+
+ # backend-dispatcher = { path = "../backend-dispatcher" } # Only for development purposes
+-# ochami-rs = { path = "../ochami-rs" } # Only for development purposes
++ochami-rs = { path = "../ochami-rs" } # Only for development purposes
+ # mesa = { path = "../mesa" } # Only for development purposes
+
+ # --- END MANTA DEPENDENCIES ---
+----
+
+. In `OpenCHAMI/ochami-rs`: remove the URL prefix
++
+[source, patch]
+----
+Subject: [PATCH] remove power-control
+
+sed -i 's|power-control/v1/||' $(find . -name "*.rs")
+---
+ src/pcs/power_cap/http_client.rs    | 8 ++++----
+ src/pcs/power_status/http_client.rs | 4 ++--
+ src/pcs/transitions/http_client.rs  | 6 +++---
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/pcs/power_cap/http_client.rs b/src/pcs/power_cap/http_client.rs
+index a9646af..1aff215 100644
+--- a/src/pcs/power_cap/http_client.rs
++++ b/src/pcs/power_cap/http_client.rs
+@@ -26,7 +26,7 @@ pub async fn get(
+         client = client_builder.build()?;
+     }
+
+-    let api_url = format!("{}/power-control/v1/power-cap", shasta_base_url);
++    let api_url = format!("{}/power-cap", shasta_base_url);
+
+     let response = client
+         .get(api_url)
+@@ -73,7 +73,7 @@ pub async fn get_task_id(
+         client = client_builder.build()?;
+     }
+
+-    let api_url = format!("{}/power-control/v1/power-cap/{}", shasta_base_url, task_id);
++    let api_url = format!("{}/power-cap/{}", shasta_base_url, task_id);
+
+     let response = client
+         .get(api_url)
+@@ -121,7 +121,7 @@ pub async fn post_snapshot(
+         client_builder.build()?
+     };
+
+-    let api_url = shasta_base_url.to_owned() + "/power-control/v1/power-cap/snapshot";
++    let api_url = shasta_base_url.to_owned() + "/power-cap/snapshot";
+
+     let response = client
+         .put(api_url)
+@@ -169,7 +169,7 @@ pub async fn patch(
+         client_builder.build()?
+     };
+
+-    let api_url = shasta_base_url.to_owned() + "/power-control/v1/power-cap/snapshot";
++    let api_url = shasta_base_url.to_owned() + "/power-cap/snapshot";
+
+     let response = client
+         .put(api_url)
+diff --git a/src/pcs/power_status/http_client.rs b/src/pcs/power_status/http_client.rs
+index 98db214..4151aa2 100644
+--- a/src/pcs/power_status/http_client.rs
++++ b/src/pcs/power_status/http_client.rs
+@@ -29,7 +29,7 @@ pub async fn get(
+         client = client_builder.build()?;
+     }
+
+-    let api_url = format!("{}/power-control/v1/power-status", shasta_base_url);
++    let api_url = format!("{}/power-status", shasta_base_url);
+
+     let xname_vec_str_opt: Option<String> = xname_vec_opt.map(|xname_vec| xname_vec.join(","));
+
+@@ -90,7 +90,7 @@ pub async fn post(
+         client_builder.build()?
+     };
+
+-    let api_url = shasta_base_url.to_owned() + "/power-control/v1/power-status";
++    let api_url = shasta_base_url.to_owned() + "/power-status";
+
+     let response = client
+         .put(api_url)
+diff --git a/src/pcs/transitions/http_client.rs b/src/pcs/transitions/http_client.rs
+index ca54d3e..e83590f 100644
+--- a/src/pcs/transitions/http_client.rs
++++ b/src/pcs/transitions/http_client.rs
+@@ -31,7 +31,7 @@ pub async fn get(
+         client = client_builder.build()?;
+     }
+
+-    let api_url = format!("{}/power-control/v1/transitions", shasta_base_url);
++    let api_url = format!("{}/transitions", shasta_base_url);
+
+     log::debug!("PCS transition URL: {}", api_url);
+
+@@ -83,7 +83,7 @@ pub async fn get_by_id(
+         client = client_builder.build()?;
+     }
+
+-    let api_url = format!("{}/power-control/v1/transitions/{}", shasta_base_url, id);
++    let api_url = format!("{}/transitions/{}", shasta_base_url, id);
+
+     let response = client
+         .get(api_url)
+@@ -156,7 +156,7 @@ pub async fn post(
+         client_builder.build()?
+     };
+
+-    let api_url = shasta_base_url.to_owned() + "/power-control/v1/transitions";
++    let api_url = shasta_base_url.to_owned() + "/transitions";
+
+     // Submit call to http api
+     let response = client
+----
+
+=== Retry to power off
+
+----
+target/debug/manta power off nodes --assume-yes x1000c0s0b3
+INFO  | Create PCS transition 'force-off' on []
+INFO  | PCS transition ID: 04ba747f-8f6c-4df5-80c2-9318251024fe
+Ok(
+    Object {
+        "automaticExpirationTime": String("2025-04-04T09:05:07.41614002Z"),
+        "createTime": String("2025-04-03T09:05:07.416139953Z"),
+        "operation": String("Force-Off"),
+        "taskCounts": Object {
+            "failed": Number(0),
+            "in-progress": Number(0),
+            "new": Number(0),
+            "succeeded": Number(0),
+            "total": Number(0),
+            "un-supported": Number(0),
+        },
+        "transitionID": String("04ba747f-8f6c-4df5-80c2-9318251024fe"),
+        "transitionStatus": String("completed"),
+    },
+)
+Ok(
+    Object {
+        "automaticExpirationTime": String("2025-04-04T09:05:07.41614002Z"),
+        "createTime": String("2025-04-03T09:05:07.416139953Z"),
+        "operation": String("Force-Off"),
+        "taskCounts": Object {
+            "failed": Number(0),
+            "in-progress": Number(0),
+            "new": Number(0),
+            "succeeded": Number(0),
+            "total": Number(0),
+            "un-supported": Number(0),
+        },
+        "transitionID": String("04ba747f-8f6c-4df5-80c2-9318251024fe"),
+        "transitionStatus": String("completed"),
+    },
+)
+Power 'Force-Off' summary - status: completed, failed: 0, in-progress: 0, succeeded: 0, total: 0. Attempt 1 of 300
+----
+
+== Next
+
+Manta is now able to communicate with PCS.
+
+But I did not test if PCS communicate well with a redfish endpoint

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -33,7 +33,8 @@ services:
       - SMD_DBUSER=smd-user
       - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
       - SMD_DBOPTS=sslmode=disable
-      - SMD_JWKS_URL=http://opaal:3333/keys
+      # - SMD_JWKS_URL=http://opaal:3333/keys
+      - SMD_JWKS_URL= # To help PCS querying hardware from SMD/HSM hardware inventory without authentication
     depends_on:
       postgres:
         condition: service_healthy

--- a/quickstart/pcs.yml
+++ b/quickstart/pcs.yml
@@ -1,0 +1,23 @@
+services:
+  pcs:
+    image: ghcr.io/openchami/pcs
+    container_name: pcs
+    restart: always
+    networks:
+      - internal
+      - jwt-internal
+    environment:
+      SMS_SERVER: http://smd:27779
+      VAULT_ENABLED: "true"
+      VAULT_ADDR: "http://vault:8200"
+      VAULT_KEYPATH: "secret/hms-creds"
+      API_URL: "http://localhost"
+      API_SERVER_PORT: ":28007"
+      API_BASE_PATH: "/v1"
+      CRAY_VAULT_JWT_FILE: /etc/keys/token
+      CRAY_VAULT_ROLE_FILE: /etc/keys/role
+      CRAY_VAULT_AUTH_PATH: auth/jwt/login
+    volumes:
+      - /home/user/keys:/etc/keys
+    ports:
+      - 28007:28007

--- a/quickstart/pcs.yml
+++ b/quickstart/pcs.yml
@@ -17,6 +17,7 @@ services:
       CRAY_VAULT_JWT_FILE: /etc/keys/token
       CRAY_VAULT_ROLE_FILE: /etc/keys/role
       CRAY_VAULT_AUTH_PATH: auth/jwt/login
+      LOG_LEVEL: DEBUG
     volumes:
       - /home/user/keys:/etc/keys
     ports:

--- a/quickstart/pcs.yml
+++ b/quickstart/pcs.yml
@@ -19,6 +19,6 @@ services:
       CRAY_VAULT_AUTH_PATH: auth/jwt/login
       LOG_LEVEL: DEBUG
     volumes:
-      - /home/user/keys:/etc/keys
+      - ./keys:/etc/keys
     ports:
       - 28007:28007

--- a/quickstart/postgres.yml
+++ b/quickstart/postgres.yml
@@ -16,8 +16,8 @@ services:
     networks:
       - internal
       - jwt-internal
-    #ports:
-    #  - 5432:5432
+    ports:
+      - 5432:5432
     healthcheck:
       test: ["CMD", "pg_isready", "--username", "${POSTGRES_USER}"]
       interval: 10s

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+until docker-compose \
+  -f base.yml \
+  -f postgres.yml \
+  -f jwt-security.yml \
+  -f haproxy-api-gateway.yml \
+  -f  openchami-svcs.yml \
+  -f autocert.yml \
+  -f coredhcp.yml \
+  -f pcs.yml \
+  -f vault.yml \
+  -f etcd.yml \
+  -f configurator.yml up -d
+do
+docker-compose \
+  -f base.yml \
+  -f postgres.yml \
+  -f jwt-security.yml \
+  -f haproxy-api-gateway.yml \
+  -f  openchami-svcs.yml \
+  -f autocert.yml \
+  -f coredhcp.yml \
+  -f pcs.yml \
+  -f vault.yml \
+  -f etcd.yml \
+  -f configurator.yml down
+done
+
+source bash_functions.sh
+gen_access_token > access_token

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -29,3 +29,4 @@ done
 
 source bash_functions.sh
 gen_access_token > access_token
+get_ca_cert > cacert.pem

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -1,32 +1,65 @@
 #!/bin/sh
 
-until docker-compose \
-  -f base.yml \
-  -f postgres.yml \
-  -f jwt-security.yml \
-  -f haproxy-api-gateway.yml \
-  -f  openchami-svcs.yml \
-  -f autocert.yml \
-  -f coredhcp.yml \
-  -f pcs.yml \
-  -f vault.yml \
-  -f etcd.yml \
-  -f configurator.yml up -d
-do
-docker-compose \
-  -f base.yml \
-  -f postgres.yml \
-  -f jwt-security.yml \
-  -f haproxy-api-gateway.yml \
-  -f  openchami-svcs.yml \
-  -f autocert.yml \
-  -f coredhcp.yml \
-  -f pcs.yml \
-  -f vault.yml \
-  -f etcd.yml \
-  -f configurator.yml down
-done
+export VAULT_ADDR=http://vault:8200
+export VAULT_TOKEN=hms
 
-source bash_functions.sh
-gen_access_token > access_token
-get_ca_cert > cacert.pem
+KEYS_PATH="${HOME}/keys"
+
+start_service() {
+	until docker-compose \
+	  -f base.yml \
+	  -f postgres.yml \
+	  -f jwt-security.yml \
+	  -f haproxy-api-gateway.yml \
+	  -f  openchami-svcs.yml \
+	  -f autocert.yml \
+	  -f coredhcp.yml \
+	  -f pcs.yml \
+	  -f vault.yml \
+	  -f etcd.yml \
+	  -f configurator.yml up -d
+	do
+	docker-compose \
+	  -f base.yml \
+	  -f postgres.yml \
+	  -f jwt-security.yml \
+	  -f haproxy-api-gateway.yml \
+	  -f  openchami-svcs.yml \
+	  -f autocert.yml \
+	  -f coredhcp.yml \
+	  -f pcs.yml \
+	  -f vault.yml \
+	  -f etcd.yml \
+	  -f configurator.yml down
+	done
+}
+
+generate_file() {
+	source bash_functions.sh
+	gen_access_token > access_token
+	get_ca_cert > cacert.pem
+}
+
+vault_configure_jwt() {
+	if vault auth list --format json | jq -e 'has("jwt/")'
+	then
+		return
+	fi
+
+	vault auth enable -path=jwt jwt
+	vault write auth/jwt/role/test-role policies="metrics" user_claim="sub" role_type="jwt" bound_audiences="test"
+	vault policy write metrics -<<-EOF
+	path "secret/hms-creds" {
+	capabilities = ["read", "list"]
+	}
+	EOF
+	vault write auth/jwt/config jwt_supported_algs=RS256 jwt_validation_pubkeys=@$KEYS_PATH/public_key.pem
+}
+
+main() {
+	start_service
+	generate_file
+	vault_configure_jwt
+}
+
+main

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -3,6 +3,8 @@
 export VAULT_ADDR=http://vault:8200
 export VAULT_TOKEN=hms
 
+XNAME=x1000c0s0b3
+
 KEYS_PATH="keys"
 
 start_service() {
@@ -64,8 +66,6 @@ vault_create_keystore() {
 }
 
 vault_populate_node() {
-	XNAME=x1000c0s0b3
-
 	vault write \
 	secret/hms-creds/"${XNAME}" \
 	refresh_interval="768h" \
@@ -77,12 +77,17 @@ vault_populate_node() {
 	Xname="${XNAME}"
 }
 
+smd_populate() {
+	manta add redfish-endpoint --id "${XNAME}" --hostname "${XNAME}" -u root -M 02:05:78:02:34:00
+}
+
 main() {
 	start_service
 	generate_file
 	vault_configure_jwt
 	vault_create_keystore
 	vault_populate_node
+	smd_populate
 }
 
 main

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -8,7 +8,7 @@ XNAME=x1000c0s0b3
 KEYS_PATH="keys"
 
 start_service() {
-	until docker compose \
+	until docker-compose \
 	  -f base.yml \
 	  -f postgres.yml \
 	  -f jwt-security.yml \
@@ -21,7 +21,7 @@ start_service() {
 	  -f etcd.yml \
 	  -f configurator.yml up -d
 	do
-	docker compose \
+	docker-compose \
 	  -f base.yml \
 	  -f postgres.yml \
 	  -f jwt-security.yml \

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -56,10 +56,33 @@ vault_configure_jwt() {
 	vault write auth/jwt/config jwt_supported_algs=RS256 jwt_validation_pubkeys=@$KEYS_PATH/public_key.pem
 }
 
+vault_create_keystore() {
+	vault secrets disable secret
+	vault secrets enable \
+	-path "secret/hms-creds" \
+	-version=1 kv
+}
+
+vault_populate_node() {
+	XNAME=x1000c0s0b3
+
+	vault write \
+	secret/hms-creds/"${XNAME}" \
+	refresh_interval="768h" \
+	Password="--REDACTED--" \
+	SNMPAuthPass="n/a" \
+	SNMPPrivPass="n/a" \
+	URL="${XNAME}/redfish/v1/Systems/Node1" \
+	Username="root" \
+	Xname="${XNAME}"
+}
+
 main() {
 	start_service
 	generate_file
 	vault_configure_jwt
+	vault_create_keystore
+	vault_populate_node
 }
 
 main

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -9,7 +9,7 @@ XNAME=x1000c0s0b3
 KEYS_PATH="keys"
 
 start_service() {
-	until docker-compose \
+	until docker compose \
 	  -f base.yml \
 	  -f postgres.yml \
 	  -f jwt-security.yml \
@@ -22,7 +22,7 @@ start_service() {
 	  -f etcd.yml \
 	  -f configurator.yml up -d
 	do
-	docker-compose \
+	docker compose \
 	  -f base.yml \
 	  -f postgres.yml \
 	  -f jwt-security.yml \

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -3,7 +3,7 @@
 export VAULT_ADDR=http://vault:8200
 export VAULT_TOKEN=hms
 
-KEYS_PATH="${HOME}/keys"
+KEYS_PATH="keys"
 
 start_service() {
 	until docker-compose \

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -11,7 +11,7 @@ start_service() {
 	  -f postgres.yml \
 	  -f jwt-security.yml \
 	  -f haproxy-api-gateway.yml \
-	  -f  openchami-svcs.yml \
+	  -f openchami-svcs.yml \
 	  -f autocert.yml \
 	  -f coredhcp.yml \
 	  -f pcs.yml \
@@ -24,7 +24,7 @@ start_service() {
 	  -f postgres.yml \
 	  -f jwt-security.yml \
 	  -f haproxy-api-gateway.yml \
-	  -f  openchami-svcs.yml \
+	  -f openchami-svcs.yml \
 	  -f autocert.yml \
 	  -f coredhcp.yml \
 	  -f pcs.yml \

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -2,6 +2,7 @@
 
 export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_TOKEN=hms
+export SUSHY_URL="http://localhost:8000"
 
 XNAME=x1000c0s0b3
 
@@ -34,6 +35,21 @@ start_service() {
 	  -f etcd.yml \
 	  -f configurator.yml down
 	done
+}
+
+_sushy_getter() {
+	if [ -z "${!1}" ]; then
+		export "${1}"="$(curl \
+			--silent \
+			"${SUSHY_URL}${2}" \
+			| jq --raw-output "${3}")"
+	fi
+}
+
+get_virtual_node_url() {
+	_sushy_getter "VIRTUAL_NODE" "/redfish/v1/Systems" '.Members[0]."@odata.id"'
+
+	echo "localhost:8000${VIRTUAL_NODE}"
 }
 
 generate_file() {
@@ -75,7 +91,7 @@ vault_populate_node() {
 	Password="--REDACTED--" \
 	SNMPAuthPass="n/a" \
 	SNMPPrivPass="n/a" \
-	URL="${XNAME}/redfish/v1/Systems/Node1" \
+	URL="$(get_virtual_node_url)" \
 	Username="root" \
 	Xname="${XNAME}"
 }

--- a/quickstart/stop.sh
+++ b/quickstart/stop.sh
@@ -1,4 +1,4 @@
-docker compose \
+docker-compose \
   -f base.yml \
   -f postgres.yml \
   -f jwt-security.yml \

--- a/quickstart/stop.sh
+++ b/quickstart/stop.sh
@@ -1,4 +1,4 @@
-docker-compose \
+docker compose \
   -f base.yml \
   -f postgres.yml \
   -f jwt-security.yml \

--- a/quickstart/stop.sh
+++ b/quickstart/stop.sh
@@ -1,0 +1,12 @@
+docker-compose \
+  -f base.yml \
+  -f postgres.yml \
+  -f jwt-security.yml \
+  -f haproxy-api-gateway.yml \
+  -f  openchami-svcs.yml \
+  -f autocert.yml \
+  -f coredhcp.yml \
+  -f pcs.yml \
+  -f vault.yml \
+  -f etcd.yml \
+  -f configurator.yml down

--- a/quickstart/test-request-on-smd.sh
+++ b/quickstart/test-request-on-smd.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+for url in \
+"/hsm/v2/service/liveness" \
+"/hsm/v2/State/Components" \
+"/hsm/v2/State/Components/Query" \
+"/hsm/v2/Inventory/ComponentEndpoints" \
+"/hsm/v2/locks/service/reservations/check" \
+"/hsm/v2/locks/service/reservations" \
+"/hsm/v2/locks/service/reservations/release" \
+"/hsm/v2/sysinfo/powermaps"
+do
+  docker exec -it smd curl -s  -H "Authorization: Bearer $(<access_token)" "http://localhost:27779$url?id=x0c0r1"
+done

--- a/quickstart/vault.yml
+++ b/quickstart/vault.yml
@@ -1,0 +1,16 @@
+services:
+  vault:
+    hostname: vault
+    container_name: vault
+    image: docker.io/library/vault:1.5.5
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=hms
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      - VAULT_ADDR=http://vault:8200
+    ports:
+      - "8200:8200"
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - internal
+      - jwt-internal


### PR DESCRIPTION
# Add Power Control Service to the quickstart

[Power Control Service](https://github.com/OpenCHAMI/power-control) (PCS) read and change the power state of nodes through redfish endpoints.

## Extra services

PCS need for running:

* [Vault](https://www.vaultproject.io/)
* [etcd](https://etcd.io/) 

## TODO

* [x] deploy vault and pcs containers.
* [x] let pcs connect to vault
* [x] populate vault with data
* [x] use [ochami CLI](https://github.com/OpenCHAMI/ochami) on pcs to obtain status
* [ ] send a power off command to a virtual BMC with Ochami/Manta CLI through PCS

## Resource

Docker compose for the development of PCS are useful to understand how work PCS.
(for example: [`docker-compose.test.ct.yaml`](https://github.com/OpenCHAMI/power-control/blob/main/docker-compose.test.ct.yaml))

[PCS design](https://github.com/OpenCHAMI/power-control/tree/main/docs/design)
