### PR TITLE
Keylime Server Deployment Recipes

### DIFF
--- a/lanl/podman-quadlets/keylime/README.md
+++ b/lanl/podman-quadlets/keylime/README.md
@@ -38,7 +38,24 @@ By default, this deployment will **generate** self-signed certificates for the K
 
 2.  Within the **"Configure Verifier"** section, locate the variable `tls_dir` or any reference to `generate`.
 
-3.  Update it to point to your certificate directory or change the generation logic to install your own cert/key pair.
+3.  The default option `generate` generates certificates and stores them at tls_dir = /var/lib/keylime/cv_ca if you want to use your own certificates, Update it to point to your certificate directory. Refer to [Redhat Keylime Documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/assembly_ensuring-system-integrity-with-keylime_security-hardening#configuring-keylime-verifier_assembly_ensuring-system-integrity-with-keylime) for more details. 
+
+To load existing keys and certificates in the configuration, define their location in the verifier configuration. The certificates must be accessible by the keylime user, under which the Keylime services are running.
+
+Create a new .conf file in the /etc/keylime/verifier.conf.d/ directory, for example, /etc/keylime/verifier.conf.d/00-keys-and-certs.conf, with the following content:
+```
+[verifier]
+tls_dir = /var/lib/keylime/cv_ca
+server_key = </path/to/server_key>
+server_key_password = <passphrase1>
+server_cert = </path/to/server_cert>
+trusted_client_ca = ['</path/to/ca/cert1>', '</path/to/ca/cert2>']
+client_key = </path/to/client_key>
+client_key_password = <passphrase2>
+client_cert = </path/to/client_cert>
+trusted_server_ca = ['</path/to/ca/cert3>', '</path/to/ca/cert4>']
+```
+
 
 > **Note**: Custom certificates should also be placed on the Keylime Agents or otherwise trusted by the Agents to ensure secure communication.
 
@@ -114,4 +131,4 @@ Next Steps
 * * * * *
 
 
-For more details on Keylime usage and advanced configuration, consult the [Keylime documentation](https://keylime.dev/) and the official Red Hat guides if you are on RHEL systems.
+For more details on Keylime usage and advanced configuration, consult the [Keylime documentation](https://keylime.dev/) and the official Red Hat [Keylime Guide](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/assembly_ensuring-system-integrity-with-keylime_security-hardening) if you are on RHEL systems.

--- a/lanl/podman-quadlets/keylime/README.md
+++ b/lanl/podman-quadlets/keylime/README.md
@@ -1,0 +1,117 @@
+# Keylime Verifier & Registrar Deployment
+
+This directory contains Ansible playbooks and roles for deploying the Keylime Server (Keylime Verifier and Registrar) as Podman quadlets.
+
+---
+
+## Prerequisites
+-------------
+
+-   **Ansible** installed on your control machine.
+
+-   A valid `inventory.yaml` file detailing the `keylime_server` host(s).
+
+-   Appropriate network connectivity from hosts running Keylime Agents to the Keylime Server (Registrar & Verifier).
+
+## Directory Structure
+-------------------
+
+```
+lanl/podman-quadlets/keylime/
+├── roles/
+│   └── keylime_verifier/
+│       ├── tasks/
+│       │   └── main.yaml
+│       └── ...
+├── site.yaml
+├── inventory.yaml (example; not stored in repo)
+└── ...
+
+```
+
+Pre-Deployment Configuration
+----------------------------
+
+By default, this deployment will **generate** self-signed certificates for the Keylime Verifier. If you would like to use **existing** or custom certificates, do the following:
+
+1.  **Edit** `lanl/podman-quadlets/keylime/roles/keylime_verifier/tasks/main.yaml`.
+
+2.  Within the **"Configure Verifier"** section, locate the variable `tls_dir` or any reference to `generate`.
+
+3.  Update it to point to your certificate directory or change the generation logic to install your own cert/key pair.
+
+> **Note**: Custom certificates should also be placed on the Keylime Agents or otherwise trusted by the Agents to ensure secure communication.
+
+Deploying the Keylime Server
+----------------------------
+
+Once you have your **inventory** and any **certificate configuration** sorted out, run the following command from this directory:
+
+```
+ansible-playbook -i inventory.yaml -l keylime_server -K site.yaml
+
+```
+
+-   `-i inventory.yaml`: Uses your specified inventory file (replace with the actual path if needed).
+
+-   `-l keylime_server`: Limits the playbook run to hosts in the `keylime_server` group.
+
+-   `-K`: Prompts for privilege escalation password (sudo).
+
+-   `site.yaml`: The main playbook which includes tasks to install and configure the Keylime Verifier & Registrar.
+
+Upon successful execution:
+
+-   The **Keylime Verifier** and **Keylime Registrar** services will be installed and configured as Podman containers (quadlets).
+
+-   Services should be running and ready to accept agent registrations.
+
+To verify the status of keylime verifier and registrar 
+
+```
+systemctl status keylime_verifier
+systemctl status keylime_registrar
+```
+
+Default Keys & Certificates
+---------------------------
+
+If you use the default key generation:
+
+-   The Keylime Verifier's self-signed CA and associated keys will be located in `/var/lib/keylime/cv_ca/` on the Keylime Server host.
+
+-   These CA certificates must be **imported by the Keylime Agent** hosts so that the Agents can securely connect and attest to the server.
+
+> **Tip**: Make sure your Keylime Agent configuration (`keylime.conf`) points to the correct CA certificate path and can verify the Verifier's SSL connection.
+
+Next Steps
+----------
+
+1.  **Deploy & Configure Keylime Agents**
+
+    -   On each node you wish to attest, install and configure the Keylime Agent.
+
+    -   Ensure the Agent's `keylime.conf` references the CA used by the Verifier.
+
+2.  **Testing & Validation**
+
+    -   Verify that each agent can register with the registrar (`keylime_registrar`) and attests successfully to the verifier.
+
+3.  **Security Hardening**
+
+    -   If you are running in a production environment, consider using official or enterprise-signed certificates and locked-down firewall rules.
+
+* * * * *
+
+### Troubleshooting
+
+-   **Service Fails to Start**: Check logs in `/var/log/` or Podman logs for containers to see if certificate paths or other environment variables are set incorrectly.
+
+-   **Agent Cannot Connect**: Ensure host firewalls allow the Verifier/Registrar ports (default 8890/8892 or custom if changed).
+
+-   **Certificate Errors**: Confirm that Agents trust the CA certificate used by the Verifier.
+
+* * * * *
+
+
+For more details on Keylime usage and advanced configuration, consult the [Keylime documentation](https://keylime.dev/) and the official Red Hat guides if you are on RHEL systems.

--- a/lanl/podman-quadlets/keylime/agent.yaml
+++ b/lanl/podman-quadlets/keylime/agent.yaml
@@ -1,0 +1,7 @@
+# site.yml
+- name: Deploy Keylime services on Rocky Linux
+  hosts: keylime_agents
+  become: true
+  roles:
+    - common              # Prepare system (TPM, packages, env)
+    - keylime_agent       # Set up Keylime Agent service (after Registrar)

--- a/lanl/podman-quadlets/keylime/group_vars/keylime_agents.yaml
+++ b/lanl/podman-quadlets/keylime/group_vars/keylime_agents.yaml
@@ -1,0 +1,5 @@
+# group_vars/keylime_agents.yml
+keylime_registrar_host: re-head
+keylime_registrar_port: 8890
+keylime_verifier_host: re-head
+keylime_verifier_port: 8881

--- a/lanl/podman-quadlets/keylime/group_vars/keylime_agents.yaml
+++ b/lanl/podman-quadlets/keylime/group_vars/keylime_agents.yaml
@@ -1,5 +1,6 @@
 # group_vars/keylime_agents.yml
-keylime_registrar_host: re-head
+# Note that Keylime Registrar and Verifier can be run on the same host as the Head Node
+keylime_registrar_host: registrar-host # IP address or hostname of the host running the Keylime Registrar typically Head Node
 keylime_registrar_port: 8890
-keylime_verifier_host: re-head
+keylime_verifier_host: registrar-host # IP address or hostname of the host running the Keylime Verifier typically Head Node
 keylime_verifier_port: 8881

--- a/lanl/podman-quadlets/keylime/group_vars/keylime_server.yaml
+++ b/lanl/podman-quadlets/keylime/group_vars/keylime_server.yaml
@@ -1,6 +1,6 @@
-keylime_verifier_ip: re-head
+keylime_verifier_ip: verifier-host # IP address or hostname to deploy the Keylime Verifier 
 keylime_verifier_port: 8881
-keylime_registrar_ip: re-head
+keylime_registrar_ip: registrar-host # IP address or hostname to deploy Keylime Registrar
 keylime_registrar_port: 8890
 keylime_registrar_image: quay.io/keylime/registrar:latest
 keylime_verifier_image: quay.io/keylime/verifier:latest

--- a/lanl/podman-quadlets/keylime/group_vars/keylime_server.yaml
+++ b/lanl/podman-quadlets/keylime/group_vars/keylime_server.yaml
@@ -1,0 +1,7 @@
+keylime_verifier_ip: re-head
+keylime_verifier_port: 8881
+keylime_registrar_ip: re-head
+keylime_registrar_port: 8890
+keylime_registrar_image: quay.io/keylime/registrar:latest
+keylime_verifier_image: quay.io/keylime/verifier:latest
+keylime_tenant_key_password: ""

--- a/lanl/podman-quadlets/keylime/inventory.yaml
+++ b/lanl/podman-quadlets/keylime/inventory.yaml
@@ -2,5 +2,5 @@
 server-node ansible_connection=local
 
 [keylime_agents]
-nid0003 ansible_host=nid0003
-nid0004 ansible_host=nid0004
+agent1 ansible_host=agent1
+agent2 ansible_host=agent2

--- a/lanl/podman-quadlets/keylime/inventory.yaml
+++ b/lanl/podman-quadlets/keylime/inventory.yaml
@@ -1,0 +1,6 @@
+[keylime_server]
+server-node ansible_connection=local
+
+[keylime_agents]
+nid0003 ansible_host=nid0003
+nid0004 ansible_host=nid0004

--- a/lanl/podman-quadlets/keylime/roles/common/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/common/tasks/main.yaml
@@ -1,0 +1,37 @@
+- name: Install Keylime and TPM dependencies
+  package:
+    name:
+      - keylime
+      - keylime_agent
+      - tpm2-tools
+      - tpm2-tss
+    state: present
+
+- name: Ensure TPM device is present (TPM enabled in BIOS)
+  stat:
+    path: /dev/tpmrm0
+  register: tpmrm
+
+- name: Fail if no TPM device found
+  fail:
+    msg: "No TPM 2.0 device found at /dev/tpmrm0. Ensure TPM is enabled and /dev/tpmrm0 exists."
+  when: not tpmrm.stat.exists
+
+# (Optional) If running Keylime agent as a host service instead of container, set TPM2TOOLS_TCTI via systemd override
+#- name: Configure TPM environment for Keylime agent service (if not containerized)
+#  copy:
+#    dest: /etc/systemd/system/keylime_agent.service.d/override.conf
+#    content: |
+#      [Service]
+#      Environment="TPM2TOOLS_TCTI=device:/dev/tpmrm0"
+#  notify: Reload systemd
+#  when: keylime_agent_host_service | default(false)
+
+- name: Configure TPM2TOOLS to use resource manager
+  copy:
+    dest: /etc/profile.d/tpm2tools.sh
+    content: |
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+    owner: root
+    group: root
+    mode: '0644'

--- a/lanl/podman-quadlets/keylime/roles/keylime_agent/handlers/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_agent/handlers/main.yaml
@@ -1,0 +1,7 @@
+- name: Reload systemd
+  command: systemctl daemon-reload
+
+- name: Restart keylime_agent
+  service:
+    name: keylime_agent.service
+    state: restarted

--- a/lanl/podman-quadlets/keylime/roles/keylime_agent/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_agent/tasks/main.yaml
@@ -23,7 +23,7 @@
     group: keylime
     mode: '0750'
 
-- name: Copy CA certificate from Registrar (re-head.usrc) to agents
+- name: Copy CA certificate from Registrar (keylime_registrar_host) to agents
   delegate_to: "{{ keylime_registrar_host }}"
   fetch:
     src: /var/lib/keylime/cv_ca/cacert.crt

--- a/lanl/podman-quadlets/keylime/roles/keylime_agent/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_agent/tasks/main.yaml
@@ -1,0 +1,90 @@
+- name: Include common TPM setup
+  import_role:
+    name: common
+
+- name: Ensure Quadlet directory exists
+  file:
+    path: /etc/containers/systemd
+    state: directory
+    mode: "0755"
+- name: Ensure agent config directory exists
+  file:
+    path: /etc/keylime/agent.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure TLS CA directory exists on agent
+  file:
+    path: /var/lib/keylime/cv_ca
+    state: directory
+    owner: keylime
+    group: keylime
+    mode: '0750'
+
+- name: Copy CA certificate from Registrar (re-head.usrc) to agents
+  delegate_to: "{{ keylime_registrar_host }}"
+  fetch:
+    src: /var/lib/keylime/cv_ca/cacert.crt
+    dest: /tmp/keylime_ca_certificates/{{ inventory_hostname }}/
+    flat: yes
+
+- name: Copy fetched CA certificate into agent's cv_ca directory
+  copy:
+    src: "/tmp/keylime_ca_certificates/{{ inventory_hostname }}/cacert.crt"
+    dest: "/var/lib/keylime/cv_ca/cacert.crt"
+    owner: keylime
+    group: keylime
+    mode: '0644'
+
+
+- name: Configure agent (IP and Registrar connection)
+  copy:
+    dest: /etc/keylime/agent.conf.d/00-agent.conf
+    content: |
+      [agent]
+      ip = 0.0.0.0
+      registrar_ip = "{{ keylime_registrar_host }}"
+      registrar_port = 8890
+      # TLS settings for Registrar (if mutual TLS enabled):
+      trusted_server_ca = "cacert.crt"
+      agent_cert = "client-cert.crt"
+      agent_key = "client-private.pem"
+    owner: root
+    group: root
+    mode: '0755'
+  notify: Restart keylime_agent
+
+- name: Configure Keylime Agent to trust Registrar (registrar IP/port)
+  copy:
+    dest: /etc/keylime/agent.conf.d/00-registrar.conf
+    content: |
+      [agent]
+      registrar_ip = "{{ keylime_registrar_host }}"
+      registrar_port = 8890
+  notify: Reload keylime_agent
+
+- name: Deploy Keylime Agent Quadlet file
+  template:
+    src: keylime_agent.container.j2
+    dest: /etc/containers/systemd/keylime_agent.container
+    owner: root
+    group: root
+    mode: "0644"
+  notify: 
+    - Reload systemd
+    - Restart keylime_agent
+
+- name: Reload systemd to register Quadlet units
+  command: systemctl daemon-reload
+  when: result is changed
+  notify: Reload systemd
+
+- name: Start Keylime Agent container service
+  systemd:
+    name: keylime_agent.service
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  notify: Reload systemd

--- a/lanl/podman-quadlets/keylime/roles/keylime_agent/templates/keylime_agent.container.j2
+++ b/lanl/podman-quadlets/keylime/roles/keylime_agent/templates/keylime_agent.container.j2
@@ -1,0 +1,41 @@
+[Unit]
+Description=Keylime Agent Service (Podman)
+After=network-online.target keylime_registrar.service
+Wants=network-online.target keylime_registrar.service
+
+[Container]
+#ContainerName=keylime_agent
+# Image={{ keylime_agent_image }}    # e.g. "quay.io/keylime/agent:latest" or custom-built image
+Image=quay.io/keylime/keylime_agent:latest
+#Image=registry.access.redhat.com/rhel9/keylime_agent:latest
+ContainerName=keylime_agent
+PublishPort=9002:9002             # expose agent's port 9002 for verifier to connect
+Environment=TPM2TOOLS_TCTI=device:/dev/tpmrm0
+User=0                            # run container as root user
+RemapUsers=no                     # disable user namespace remapping (container root == host root)
+DropCapability=                   # do not drop capabilities (allow full privileges)
+# Optionally, explicitly allow TPM device (if needed by cgroups):
+# DeviceAllow=/dev/tpmrm0 rwm
+Network=host
+# Mount TPM device into the container (for hardware TPM access)
+Device=/dev/tpm0
+Device=/dev/tpmrm0
+AddDevice=/dev/tpmrm0:/dev/tpmrm0:rwm
+AddDevice=-/dev/tpm0:/dev/tpm0:rwm
+AddCapability=CAP_SYS_ADMIN
+
+# Mount Keylime data (certificates and keys)
+Volume=/var/lib/keylime:/var/lib/keylime:Z
+
+Volume=/etc/keylime/agent.conf.d:/etc/keylime/agent.conf.d:Z
+Volume=/var/lib/keylime/cv_ca:/var/lib/keylime/cv_ca:Z
+Volume=/sys/kernel/security/ima:/sys/kernel/security/ima:ro
+
+
+# Run the agent with necessary privileges (needs access to TPM device)
+SecurityOpt=label=disable
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/lanl/podman-quadlets/keylime/roles/keylime_registrar/handlers/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_registrar/handlers/main.yaml
@@ -1,0 +1,7 @@
+- name: Reload systemd
+  command: systemctl daemon-reload
+
+- name: Restart keylime_registrar
+  service:
+    name: keylime_registrar.service
+    state: restarted

--- a/lanl/podman-quadlets/keylime/roles/keylime_registrar/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_registrar/tasks/main.yaml
@@ -74,13 +74,3 @@
     enabled: yes  # enable is handled by [Install], but this ensures it’s active now
     daemon_reload: yes
   notify: Reload systemd
-
-#- name: Open Keylime registrar firewall ports (8890, 8891)
-#  firewalld:
-#    port: "{{ item }}"
-#    permanent: yes
-#    immediate: yes
-#    state: enabled
-#  with_items:
-#    - "8890/tcp"
-#    - "8891/tcp"

--- a/lanl/podman-quadlets/keylime/roles/keylime_registrar/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_registrar/tasks/main.yaml
@@ -1,0 +1,86 @@
+#- name: Include common TPM setup
+#  import_role:
+#    name: common
+
+- name: Ensure Quadlet directory exists
+  file:
+    path: /etc/containers/systemd
+    state: directory
+    mode: '0755'
+
+- name: Ensure registrar config directory exists
+  file:
+    path: /etc/keylime/registrar.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Configure registrar (bind IP and TLS)
+  copy:
+    dest: /etc/keylime/registrar.conf.d/00-registrar.conf
+    content: |
+      [registrar]
+      ip = 0.0.0.0
+      tls_dir = /var/lib/keylime/cv_ca
+      server_cert = server-cert.crt
+      server_key = server-private.pem
+      trusted_client_ca = ["cacert.crt"]
+    owner: root
+    group: root
+    mode: '0755'
+  register: registrar_quadlet  
+  notify: Restart keylime_registrar
+
+# Optional: fix ownership on entire cert dir
+- name: Ensure keylime user owns the full TLS CA directory
+  file:
+    path: /var/lib/keylime/cv_ca
+    recurse: yes
+    owner: keylime
+    group: keylime
+    mode: '0755'
+
+# Optional: fix ownership on entire cert dir
+- name: Ensure keylime user owns the full TLS CA directory
+  file:
+    path: /var/lib/keylime/cv_ca
+    recurse: yes
+    owner: 1000
+    group: 1000
+    mode: '0755'
+
+- name: Deploy Keylime Registrar Quadlet file
+  template:
+    src: keylime_registrar.container.j2
+    dest: /etc/containers/systemd/keylime_registrar.container
+    owner: root
+    group: root
+    mode: '0755'
+  notify: Reload systemd
+
+
+
+- name: Reload systemd to register Quadlet units
+  command: systemctl daemon-reload
+  #when: registrar_quadlet.changed   # only reload if the template was updated
+  notify: Reload systemd
+
+
+- name: Start Keylime Registrar container service
+  systemd:
+    name: keylime_registrar.service
+    state: started
+    enabled: yes  # enable is handled by [Install], but this ensures it’s active now
+    daemon_reload: yes
+  notify: Reload systemd
+
+#- name: Open Keylime registrar firewall ports (8890, 8891)
+#  firewalld:
+#    port: "{{ item }}"
+#    permanent: yes
+#    immediate: yes
+#    state: enabled
+#  with_items:
+#    - "8890/tcp"
+#    - "8891/tcp"

--- a/lanl/podman-quadlets/keylime/roles/keylime_registrar/templates/keylime_registrar.container.j2
+++ b/lanl/podman-quadlets/keylime/roles/keylime_registrar/templates/keylime_registrar.container.j2
@@ -1,0 +1,39 @@
+[Unit]
+Description=Keylime Registrar Service (Podman)
+After=network-online.target keylime_verifier.service
+Wants=network-online.target keylime_verifier.service
+
+[Container]
+# Image={{ keylime_registrar_image }}  # e.g. "quay.io/keylime/registrar:latest"
+Image=quay.io/keylime/keylime_registrar:latest
+ContainerName=keylime_registrar
+# Expose Registrar port on host (8890)
+PublishPort=8890:8890               # expose registrar's port 8890 on host
+PublishPort=8891:8891               # expose registrar's port 8891 on host
+Environment=TPM2TOOLS_TCTI=device:/dev/tpmrm0
+
+# TLS key password for server cert (required if encrypted)
+#Environment=KEYLIME_REGISTRAR_SERVER_KEY_PASSWORD={{ keylime_tls_passphrase | default("CHANGEME") }}
+
+# Optional: if you use a client cert to contact the registrar (e.g. verifier or tenant)
+#Environment=KEYLIME_REGISTRAR_CLIENT_KEY_PASSWORD={{ keylime_tls_passphrase | default("CHANGEME") }}
+
+
+
+
+# Essential and correct volume mounts
+Volume=/var/lib/keylime/cv_ca:/var/lib/keylime/cv_ca:Z
+Volume=/etc/keylime/verifier.conf.d:/etc/keylime/verifier.conf.d:Z
+
+
+
+# Mount volume for persistent keylime data (if using a podman volume)
+# Make sure it's defined separately as a keylime-data.volume unit or create it via podman
+# Volume=keylime-data.volume:/var/lib/keylime
+
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/lanl/podman-quadlets/keylime/roles/keylime_tenant/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_tenant/tasks/main.yaml
@@ -1,0 +1,52 @@
+# roles/keylime_tenant/tasks/main.yml
+- name: Install Keylime tenant CLI
+  dnf:
+    name: keylime
+    state: present
+  # The keylime package provides the 'keylime_tenant' CLI.
+
+- name: Ensure tenant config directory exists
+  file:
+    path: /etc/keylime/tenant.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Configure tenant CLI (TLS and service endpoints)
+  copy:
+    dest: /etc/keylime/tenant.conf.d/00-tenant.conf
+    content: |
+      [tenant]
+      registrar_ip = 127.0.0.1
+      registrar_port = 8891
+      verifier_ip = 127.0.0.1
+      verifier_port = 8881
+      tls_dir = /var/lib/keylime/cv_ca
+      client_cert = default
+      client_key = default
+      trusted_server_ca = default
+      enable_agent_mtls = True
+      tpm_cert_store = /var/lib/keylime/tpm_cert_store
+      max_payload_size = 1048576
+      accept_tpm_hash_algs = ['sha512', 'sha384', 'sha256']
+      accept_tpm_encryption_algs = ['ecc', 'rsa']
+      accept_tpm_signing_algs =  ['ecschnorr', 'rsassa']
+      exponential_backoff = True
+      client_key_password =
+      retry_interval = 2
+      max_retries = 5
+      request_timeout = 60
+      require_ek_cert = True
+      ek_check_script = /usr/local/bin/ek_check.sh
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Secure Keylime certificate directory
+  file:
+    path: /var/lib/keylime/cv_ca
+    recurse: yes
+    owner: keylime
+    group: keylime
+    mode: '0755'

--- a/lanl/podman-quadlets/keylime/roles/keylime_verifier/handlers/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_verifier/handlers/main.yaml
@@ -1,0 +1,7 @@
+- name: Reload systemd
+  command: systemctl daemon-reload
+
+- name: Restart keylime_verifier
+  service:
+    name: keylime_verifier.service
+    state: restarted

--- a/lanl/podman-quadlets/keylime/roles/keylime_verifier/tasks/main.yaml
+++ b/lanl/podman-quadlets/keylime/roles/keylime_verifier/tasks/main.yaml
@@ -1,0 +1,88 @@
+#- name: Include common TPM setup
+#  import_role:
+#    name: common
+
+- name: Ensure Quadlet directory exists
+  file:
+    path: /etc/containers/systemd
+    state: directory
+    mode: '0755'
+
+- name: Ensure verifier config directory exists
+  file:
+    path: /etc/keylime/verifier.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+# Optional: fix ownership on entire cert dir
+- name: Ensure keylime user owns the full TLS CA directory
+  file:
+    path: /var/lib/keylime/cv_ca
+    recurse: yes
+    owner: 1000
+    group: 1000
+    mode: '0755'
+
+
+- name: Configure verifier (IP, Registrar, TLS)
+  copy:
+    dest: /etc/keylime/verifier.conf.d/00-verifier.conf
+    content: |
+      [verifier]
+      ip = 0.0.0.0
+      registrar_ip = 127.0.0.1
+      registrar_port = 8890
+      tls_dir = generate
+    owner: root
+    group: root
+    mode: '0755'
+  notify: Restart keylime_verifier
+
+
+
+- name: Deploy Keylime Verifier Quadlet file
+  template:
+    src: keylime_verifier.container.j2
+    dest: /etc/containers/systemd/keylime_verifier.container
+    owner: root
+    group: root
+    mode: '0755'
+  register: verifier_quadlet  
+  notify: Reload systemd
+
+
+#- name: Open Keylime verifier firewall ports (8881)
+#  firewalld:
+#    port: "{{ item }}"
+#    permanent: yes
+#    immediate: yes
+#    state: enabled
+#  with_items:
+#    - "8881/tcp"
+
+# Optional: fix ownership on entire cert dir
+- name: Ensure keylime user owns the full TLS CA directory
+  file:
+    path: /var/lib/keylime/cv_ca
+    recurse: yes
+    owner: keylime
+    group: keylime
+    mode: '0755'
+
+- name: Reload systemd to register Quadlet units
+  command: systemctl daemon-reload
+  #when: verifier_quadlet.changed 
+  notify: Reload systemd
+
+
+
+
+- name: Start Keylime Verifier container service (will auto-start registrar if not running)
+  systemd:
+    name: keylime_verifier.service
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  notify: Reload systemd

--- a/lanl/podman-quadlets/keylime/roles/keylime_verifier/templates/keylime_verifier.container.j2
+++ b/lanl/podman-quadlets/keylime/roles/keylime_verifier/templates/keylime_verifier.container.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=Keylime Verifier Service (Podman)
+After=network-online.target 
+Wants=network-online.target
+
+[Container]
+Image=quay.io/keylime/keylime_verifier:latest
+ContainerName=keylime_verifier
+PublishPort=8881:8881                # expose verifier's port 8881 on host
+Environment=TPM2TOOLS_TCTI=device:/dev/tpmrm0
+
+#Environment=KEYLIME_VERIFIER_SERVER_KEY_PASSWORD={{ keylime_tls_passphrase | default("CHANGEME") }}
+#Environment=KEYLIME_VERIFIER_CLIENT_KEY_PASSWORD={{ keylime_tls_passphrase | default("CHANGEME") }}
+
+
+# Essential and correct volume mounts
+Volume=/var/lib/keylime/cv_ca:/var/lib/keylime/cv_ca:Z
+Volume=/etc/keylime/verifier.conf.d:/etc/keylime/verifier.conf.d:Z
+
+
+
+# Mount volume for persistent keylime data (if using a podman volume)
+# Make sure it's defined separately as a keylime-data.volume unit or create it via podman
+# Volume=keylime-data.volume:/var/lib/keylime
+
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/lanl/podman-quadlets/keylime/site.yaml
+++ b/lanl/podman-quadlets/keylime/site.yaml
@@ -1,0 +1,10 @@
+# site.yml
+- name: Deploy Keylime services on Rocky Linux
+  hosts: keylime_server
+  become: true
+  roles:
+    #- common              # Prepare system (TPM, packages, env)
+    - keylime_verifier    # Set up Keylime Verifier service (after Registrar)
+    - keylime_registrar   # Set up Keylime Registrar service 
+    #- keylime_agent       # Set up Keylime Agent service (after Registrar)
+    - keylime_tenant      # Set up Keylime Tenant CLI (after services)


### PR DESCRIPTION
Integrated Keylime server deployment using quadlets in the headnode.  This commit also has recipes for agent deployment too, but the emphasis of this pull request is on Server. The agents will be deployed through image-builder. 