### PR TITLE
Fix xnames

### DIFF
--- a/quickstart-pcs/README.adoc
+++ b/quickstart-pcs/README.adoc
@@ -141,7 +141,7 @@ make run
 +
 [source, shell]
 ----
-docker exec x1000c0s0b5 bash -c "ssh-keyscan \"$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')\" > /root/.ssh/known_hosts"
+docker exec x1000c0s0b0 bash -c "ssh-keyscan \"$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')\" > /root/.ssh/known_hosts"
 ----
 
 . Add sushy-emulator as RFE
@@ -149,8 +149,8 @@ docker exec x1000c0s0b5 bash -c "ssh-keyscan \"$(docker network inspect bridge -
 [source, shell]
 ----
 curl -X POST -d '{"RedfishEndpoints":[{
-  "ID":"x1000c0s0b5",
-  "FQDN":"x1000c0s0b5",
+  "ID":"x1000c0s0b0",
+  "FQDN":"x1000c0s0b0",
   "RediscoverOnUpdate":true,
   "User":"root",
   "Password":"root_password"
@@ -161,8 +161,8 @@ curl -X POST -d '{"RedfishEndpoints":[{
 +
 [source, shell]
 ----
-bash transition.sh x1000c0s0b5n0 force-off
-bash transition.sh x1000c0s0b5n0 on
+bash transition.sh x1000c0s0b0n0 force-off
+bash transition.sh x1000c0s0b0n0 on
 ----
 
 == extra

--- a/quickstart-pcs/exploration-integrate-pcs.adoc
+++ b/quickstart-pcs/exploration-integrate-pcs.adoc
@@ -69,7 +69,7 @@ From this quickstart folder.
 Manta cli
 
 ----
-manta power off nodes --assume-yes x1000c0s0b3
+manta power off nodes --assume-yes x1000c0s0b1
 ERROR - Could not power off node/s '[]'. Reason:
 ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
 No server is available to handle this request.
@@ -120,7 +120,7 @@ No server is available to handle this request.
 ----
 ochami pcs status
 {"pcs":"ready"}
-manta power off nodes --assume-yes x1000c0s0b3
+manta power off nodes --assume-yes x1000c0s0b1
 INFO  | Create PCS transition 'force-off' on []
 ERROR - Could not power off node/s '[]'. Reason:
 ERROR - Message: ERROR - MESA: <html><body><h1>503 Service Unavailable</h1>
@@ -270,7 +270,7 @@ index ca54d3e..e83590f 100644
 === Retry to power off
 
 ----
-target/debug/manta power off nodes --assume-yes x1000c0s0b3
+target/debug/manta power off nodes --assume-yes x1000c0s0b1
 INFO  | Create PCS transition 'force-off' on []
 INFO  | PCS transition ID: 04ba747f-8f6c-4df5-80c2-9318251024fe
 Ok(

--- a/quickstart-pcs/rfe.yml
+++ b/quickstart-pcs/rfe.yml
@@ -1,12 +1,12 @@
 services:
   rfemulator3:
-    hostname: x1000c0s0b3
-    container_name: x1000c0s0b3
+    hostname: x1000c0s0b1
+    container_name: x1000c0s0b1
     image: ghcr.io/openchami/csm-rie:v1.6.7
     environment:
       - MOCKUPFOLDER=EX425
       - MAC_SCHEMA=Mountain
-      - XNAME=x1000c0s0b3
+      - XNAME=x1000c0s0b1
       - PORT=443
     ports:
       - 443:443

--- a/quickstart-pcs/run.sh
+++ b/quickstart-pcs/run.sh
@@ -4,7 +4,7 @@ export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_TOKEN=hms
 export SUSHY_URL="http://localhost:8000"
 
-XNAME=x1000c0s0b3
+XNAME=x1000c0s0b1
 
 KEYS_PATH="keys"
 
@@ -78,8 +78,8 @@ smd_populate() {
 	# 1: https://github.com/OpenCHAMI/power-control/blob/main/docker-compose.test.ct.yaml#L108
 
 	curl -X POST -d '{"RedfishEndpoints":[{
-	  "ID":"x1000c0s0b3",
-	  "FQDN":"x1000c0s0b3",
+	  "ID":"x1000c0s0b1",
+	  "FQDN":"x1000c0s0b1",
 	  "RediscoverOnUpdate":true,
 	  "User":"root",
 	  "Password":"root_password"

--- a/quickstart-pcs/sushy.yml
+++ b/quickstart-pcs/sushy.yml
@@ -1,8 +1,8 @@
 services:
   sushy:
     image: tgrivel/sushy-emulator:0.0.3
-    hostname: x1000c0s0b5
-    container_name: x1000c0s0b5
+    hostname: x1000c0s0b0
+    container_name: x1000c0s0b0
     restart: always
     networks:
       - internal

--- a/quickstart-pcs/transition.sh
+++ b/quickstart-pcs/transition.sh
@@ -33,7 +33,7 @@ main() {
 if [ $# -eq 0 ]; then
 	echo "error: missing argument"
 	echo "example:"
-	echo "${0} x1000c0s0b3n0 force-off"
+	echo "${0} x1000c0s0b1n0 force-off"
 	exit 1
 fi
 


### PR DESCRIPTION
xnames x1000c0s0b3 and x1000c0s0b5 are not valid values (ref https://cray-hpe.github.io/docs-csm/en-10/operations/component_names_xnames/).
I am changing them:

- from x1000c0s0b3 to x1000c0s0b1
- from x1000c0s0b5 to x1000c0s0b0

This is not working because I don't see the redfish hardware being populated into redffish components when creating a redfisn endpoint forx1000c0s0b0.

I am guessing because something to change in container x1000c0s0b0 image?