### PR TITLE
fix(access_token): update network name

### DIFF
--- a/quickstart-pcs/.gitignore
+++ b/quickstart-pcs/.gitignore
@@ -1,0 +1,4 @@
+sushy-emulator
+access_token
+keys
+policy.yml

--- a/quickstart-pcs/autocert.yml
+++ b/quickstart-pcs/autocert.yml
@@ -6,6 +6,7 @@ volumes:
 
 networks:
   cert-internal:
+    name: openchami-quickstart-cert-internal
 
 services:
   # step-ca is a local CA that can be used to issue certificates.  

--- a/quickstart-pcs/base.yml
+++ b/quickstart-pcs/base.yml
@@ -1,5 +1,8 @@
 networks:
   internal:
+    name: openchami-quickstart-internal
   jwt-internal:
+    name: openchami-quickstart-jwt-internal
   external:
+    name: openchami-quickstart-external
     driver: bridge

--- a/quickstart-pcs/bash_functions.sh
+++ b/quickstart-pcs/bash_functions.sh
@@ -37,7 +37,7 @@ retrieve_access_token() {
     local CLIENT_ID=$1
     local CLIENT_SECRET=$2
 
-    ${CONTAINER_CMD:-docker} run --rm --network quickstart-pcs_jwt-internal "${CURL_CONTAINER}:${CURL_TAG}" -s -u "$CLIENT_ID:$CLIENT_SECRET" \
+    ${CONTAINER_CMD:-docker} run --rm --network openchami-quickstart-jwt-internal "${CURL_CONTAINER}:${CURL_TAG}" -s -u "$CLIENT_ID:$CLIENT_SECRET" \
     -d grant_type=client_credentials \
     -d scope=openid+smd.read \
     http://hydra:4444/oauth2/token

--- a/quickstart-pcs/bash_functions.sh
+++ b/quickstart-pcs/bash_functions.sh
@@ -37,7 +37,7 @@ retrieve_access_token() {
     local CLIENT_ID=$1
     local CLIENT_SECRET=$2
 
-    ${CONTAINER_CMD:-docker} run --rm --network quickstart_jwt-internal "${CURL_CONTAINER}:${CURL_TAG}" -s -u "$CLIENT_ID:$CLIENT_SECRET" \
+    ${CONTAINER_CMD:-docker} run --rm --network quickstart-pcs_jwt-internal "${CURL_CONTAINER}:${CURL_TAG}" -s -u "$CLIENT_ID:$CLIENT_SECRET" \
     -d grant_type=client_credentials \
     -d scope=openid+smd.read \
     http://hydra:4444/oauth2/token


### PR DESCRIPTION
# fix(access_token): update network name

I didn't test correctly while #118.

The `access_token` file isn't create correctly.

I didn't expect the name of the folder to be important.

This PR fix the `bash_functions.sh` script and avoid next problem if we rename this folder.

We can apply the same patch to the `quickstart` folder.

## chore(docker): define a fix name for networks

That makes sense, because if you rename the
folder, the `bash_functions.sh` script will
not work because the network name is
hardcoded in the script.

## fix(functions): network name has change

The folder name has changed from
`quickstart` to `quickstart-pcs`.

## chore: gitignore

I totally forgot to add this gitignore while the PR #118.