### PR TITLE
Adding missing quadlet and docker healthchecks 

### DIFF
--- a/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
@@ -57,7 +57,7 @@ _step_ca_quadlets:
     networks:
       - ochami-cert-internal.network
     health:
-      cmd: '["step", "ca", "health"]'
+      cmd: "step ca health"
       interval: '10s'
       retries: 5
       timeout: '10s'
@@ -83,7 +83,7 @@ _postgres_quadlets:
       - ochami-internal.network
       - ochami-jwt-internal.network
     health:
-      cmd: '["pg_isready", "--dbname", "${POSTGRES_USER}", "--username", "${POSTGRES_USER}"]'
+      cmd: "pg_isready --dbname ${POSTGRES_USER} --username ${POSTGRES_USER}"
       interval: 10s
       timeout: 10s
       retries: 5
@@ -170,7 +170,7 @@ _hydra_quadlets:
     networks:
       - ochami-jwt-internal.network
     health:
-      cmd: '["wget", "--spider", "-q", "http://hydra:4444/health/alive"]'
+      cmd: "wget --spider -q http://hydra:4444/health/alive"
       interval: 10s
       timeout: 10s
       retries: 10
@@ -209,7 +209,7 @@ _opaal_quadlets:
     post_start:
       - sleep 10s
     health:
-      cmd: '["curl", "--fail", "--silent", "http://opaal:3333/keys"]'
+      cmd: "curl --fail --silent http://opaal:3333/keys"
       interval: 5s
       timeout: 10s
       retries: 60
@@ -246,7 +246,7 @@ _ochami_quadlets:
       - SMD_DBOPTS=sslmode=disable
       - SMD_JWKS_URL=http://opaal:3333/keys
     health:
-      cmd: '["curl", "--fail", "--silent", "http://localhost:27779/hsm/v2/service/ready"]'
+      cmd: "curl --fail --silent http://localhost:27779/hsm/v2/service/ready"
       interval: 5s
       retries: 60
       timeout: 10s
@@ -297,7 +297,7 @@ _ochami_quadlets:
     networks:
       - ochami-internal.network
     health:
-      cmd: '["curl", "--fail", "--silent", "http://localhost:27778/boot/v1/service/status"]'
+      cmd: "curl --fail --silent http://localhost:27778/boot/v1/service/status"
       interval: 5s
       retries: 60
       timeout: 10s
@@ -338,6 +338,11 @@ _haproxy_quadlets:
       - bss.service
       - acme-deploy.service
       - cloud-init-server.service
+    health:
+      cmd: "bash -c 'exec 3<>/dev/tcp/haproxy/8404; echo -e \"GET / HTTP/1.1\\nConnection: close\\n\" >&3; cat <&3 | grep \"200 OK\"'"
+      interval: '10s'
+      retries: 5
+      timeout: '10s'
 
 _coresmd_quadlets:
   - name: coresmd

--- a/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
@@ -56,6 +56,11 @@ _step_ca_quadlets:
       - DOCKER_STEPCA_INIT_ACME=true
     networks:
       - ochami-cert-internal.network
+    health:
+      cmd: '["step", "ca", "health"]'
+      interval: '10s'
+      retries: 5
+      timeout: '10s'
     no_hosts: true
     after: 
       - ochami-jenga.service
@@ -77,6 +82,11 @@ _postgres_quadlets:
     networks:
       - ochami-internal.network
       - ochami-jwt-internal.network
+    health:
+      cmd: '["pg_isready", "--dbname", "${POSTGRES_USER}", "--username", "${POSTGRES_USER}"]'
+      interval: 10s
+      timeout: 10s
+      retries: 5
     after:
       - ochami-jenga.service
 
@@ -159,6 +169,12 @@ _hydra_quadlets:
       - ochami-jenga.service
     networks:
       - ochami-jwt-internal.network
+    health:
+      cmd: '["wget", "--spider", "-q", "http://hydra:4444/health/alive"]'
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
   # Fix for hydra race condition
   - name: hydra-gen-jwks
     image: cgr.dev/chainguard/curl:latest
@@ -192,11 +208,11 @@ _opaal_quadlets:
       - "{{ cluster_name }}.{{ cluster_domain }}:{{ cluster_boot_ip }}"
     post_start:
       - sleep 10s
-        #    health:
-        #      cmd: 'curl --fail --silent http://opaal:3333/keys'
-        #      interval: 5s
-        #      timeout: 10s
-        #      retries: 60
+    health:
+      cmd: '["curl", "--fail", "--silent", "http://opaal:3333/keys"]'
+      interval: 5s
+      timeout: 10s
+      retries: 60
     after:
       - opaal-idp.service
 
@@ -229,6 +245,12 @@ _ochami_quadlets:
       - SMD_DBUSER=smd-user
       - SMD_DBOPTS=sslmode=disable
       - SMD_JWKS_URL=http://opaal:3333/keys
+    health:
+      cmd: '["curl", "--fail", "--silent", "http://localhost:27779/hsm/v2/service/ready"]'
+      interval: 5s
+      retries: 60
+      timeout: 10s
+
     after:
       - smd-init.service
       - opaal.service
@@ -274,6 +296,12 @@ _ochami_quadlets:
       - opaal.service
     networks:
       - ochami-internal.network
+    health:
+      cmd: '["curl", "--fail", "--silent", "http://localhost:27778/boot/v1/service/status"]'
+      interval: 5s
+      retries: 60
+      timeout: 10s
+
   - name: cloud-init-server
     image: ghcr.io/openchami/cloud-init:v1.2.1
     envs:

--- a/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
+++ b/lanl/podman-quadlets/inventory/group_vars/ochami/quadlets.yaml
@@ -194,6 +194,11 @@ _opaal_quadlets:
       - /etc/ochami/configs:/opaal/config/
     networks:
       - ochami-jwt-internal
+    health:
+      cmd: "curl --fail --silent http://opaal-idp:3332/.well-known/jwks.json"
+      interval: 5s
+      timeout: 10s
+      retries: 60
     after:
       - hydra-gen-jwks.service
   - name: opaal
@@ -303,7 +308,7 @@ _ochami_quadlets:
       timeout: 10s
 
   - name: cloud-init-server
-    image: ghcr.io/openchami/cloud-init:v1.2.1
+    image: ghcr.io/openchami/cloud-init:v1.2.3
     envs:
       - LISTEN_ADDR=:27777
       - SMD_URL=http://smd:27779
@@ -319,6 +324,11 @@ _ochami_quadlets:
       - CAP_NET_ADMIN
 #    command: '/usr/local/bin/cloud-init-server --listen 0.0.0.0:27777 --smd-url http://smd:27779 --token-url http://opaal:3333/token --jwks-url http://opaal:3333/keys --impersonation=true --cluster-name {{ cluster_name }} --wireguard-server {{ cloud_init_wireguard_server }}/16 --wireguard-only --debug'
     command: '/usr/local/bin/cloud-init-server --listen 0.0.0.0:27777 --smd-url http://smd:27779 --token-url http://opaal:3333/token --impersonation=true --cluster-name {{ cluster_name }}'
+    health:
+      cmd: "curl http://127.0.0.1:27777/cloud-init/version"
+      interval: '10s'
+      retries: 5
+      timeout: '10s'
 
 _haproxy_quadlets:
   - name: haproxy
@@ -346,7 +356,7 @@ _haproxy_quadlets:
 
 _coresmd_quadlets:
   - name: coresmd
-    image: ghcr.io/openchami/coredhcp:v0.3.0
+    image: ghcr.io/openchami/coredhcp:v0.3.1
     capabilities:
       - NET_ADMIN
       - NET_RAW
@@ -357,6 +367,11 @@ _coresmd_quadlets:
       - host
     after:
       - haproxy.service
+    health:
+      cmd: "dhcping -c {{cluster_boot_ip}} -s {{cluster_boot_ip}} -h 00:00:00:00:00:00"
+      interval: '10s'
+      retries: 5
+      timeout: '10s'
 
 _image_server_quadlets:
   - name: image-server
@@ -367,6 +382,13 @@ _image_server_quadlets:
       - '{{ cluster_boot_ip }}:8080:80'
     pre_start:
       - mkdir -p /data/domain-images
+      - echo "Service Available" > /data/domain-images/index.html
+      - chmod a+r  /data/domain-images/index.html
+    health:
+      cmd: "curl --fail --silent http://image-server"
+      interval: '10s'
+      retries: 5
+      timeout: '10s'
 
 _configurator_quadlets:
   - name: configurator

--- a/lanl/podman-quadlets/roles/quadlet/templates/container.j2
+++ b/lanl/podman-quadlets/roles/quadlet/templates/container.j2
@@ -85,7 +85,7 @@ Network={{ network  }}
 {% if item.health is defined %}
 # Health Checks
 # Health Check Command
-HealthCmd=CMD-SHELL '{{ item.health.cmd }}'
+HealthCmd={{ item.health.cmd }}
 # Health Check Interval
 {% if item.health.interval is defined %}
 HealthInterval={{ item.health.interval }}

--- a/quickstart/coredhcp.yml
+++ b/quickstart/coredhcp.yml
@@ -1,6 +1,6 @@
 services:
   coredhcp:
-    image: ghcr.io/openchami/coredhcp:v0.3.0
+    image: ghcr.io/openchami/coredhcp:v0.3.1
     container_name: coredhcp
     hostname: coredhcp
     network_mode: host
@@ -14,7 +14,7 @@ services:
       - "-L"
       - "debug"
     healthcheck:
-      test: pgrep coredhcp
+      test: "dhcping -c {{cluster_boot_ip}} -s {{cluster_boot_ip}} -h 00:00:00:00:00:00"
       interval: 5s
       timeout: 10s
       retries: 60

--- a/quickstart/haproxy-api-gateway.yml
+++ b/quickstart/haproxy-api-gateway.yml
@@ -15,7 +15,7 @@ services:
       - internal
       - jwt-internal
     healthcheck:
-      test: ["CMD", "haproxy", "-c", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+      test: ["CMD", "bash", "-c", "'exec 3<>/dev/tcp/haproxy/8404; echo -e \"GET / HTTP/1.1\\nConnection: close\\n\" >&3; cat <&3 | grep \"200 OK\"'"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -4,7 +4,7 @@ services:
 ###
   # sets up postgres for SMD data
   smd-init:
-    image: ghcr.io/openchami/smd:v2.17.7
+    image: ghcr.io/openchami/smd:v2.17.71
     container_name: smd-init
     hostname: smd-init
     environment:
@@ -117,7 +117,7 @@ services:
 ###
   # cloud-init server, with the secure route disabled for now
   cloud-init:
-    image: ghcr.io/openchami/cloud-init:v0.1.1
+    image: ghcr.io/openchami/cloud-init:v1.2.3
     container_name: cloud-init
     hostname: cloud-init
     environment:
@@ -133,3 +133,8 @@ services:
         condition: service_healthy
     networks:
       - internal
+    healthcheck:
+      test: ["CMD", "curl", "http://127.0.0.1:27777/cloud-init/version"]
+      interval: 5s
+      timeout: 10s
+      retries: 60

--- a/quickstart/openchami-svcs.yml
+++ b/quickstart/openchami-svcs.yml
@@ -4,7 +4,7 @@ services:
 ###
   # sets up postgres for SMD data
   smd-init:
-    image: ghcr.io/openchami/smd:v2.17.71
+    image: ghcr.io/openchami/smd:v2.17.7
     container_name: smd-init
     hostname: smd-init
     environment:


### PR DESCRIPTION
- Fixed quadlet health check cmd stanza causing all quadlet bases health checks to fail.
- Added/updated quadlet health checks as needed
- updated coredhcp to v0.3.1
- updated cloud-init to v1.2.3
- Added missing health checks to the quickstart that were added in the updated container versions 