### PR TITLE
Add ArgoCD and Kustomize deployment

### DIFF
--- a/lbnl/argo/README.md
+++ b/lbnl/argo/README.md
@@ -1,0 +1,342 @@
+# Self-contained OpenCHAMI demo environment
+
+These instructions cover creation of a local self-contained OpenCHAMI test
+cluster and Redfish-managed VM using [KinD](https://kind.sigs.k8s.io/) and
+[KubeVirt](https://kubevirt.io/).
+
+## Runbook
+
+### Cluster creation
+
+I create my KinD clusters using the [ktf wrapper](https://github.com/Kong/kubernetes-testing-framework),
+mostly to provide a convenient metallb install and network configuration:
+
+```
+ktf env create --name test --addon metallb
+```
+
+https://mauilion.dev/posts/kind-metallb/ describes the manual steps for the
+metalb install and creation of an IPAddressPool appropriate for your KinD
+Docker network.
+
+### Supporting infrastructure installation
+
+Install cert-manager and ArgoCD:
+
+```
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+I'd originally included cert-manager as part of the virtual machine
+Application, but for some reason Argo was unable to recognize its webhook
+certificate, preventing it from deploying Certificate resources.
+
+### Configure Argo access
+
+From the [Argo _Getting Started_ guide](https://argo-cd.readthedocs.io/en/stable/getting_started/),
+change the admin Service to a LoadBalancer and set up your account:
+
+```
+kubectl patch svc argocd-server -n argocd -p '{"spec": {"type": "LoadBalancer"}}'
+```
+
+Retrieve the Service external IP and initial password:
+
+```
+kubectl get svc -n argocd argocd-server -ojson | jq .status.loadBalancer.ingress[0].ip -r
+172.19.128.1
+```
+
+```
+argocd admin initial-password -n argocd
+```
+
+Log in using the initial password:
+
+```
+argocd login 172.19.128.1
+```
+
+Update the password to something else:
+
+```
+argocd account update-password
+```
+
+You'll now be able to log in to the web UI at https://172.19.128.1/ (the
+username is `admin`). This guide will use the CLI to create and sync
+Applications, but the UI's useful for seeing the status of managed resources.
+
+### Set up a private repository
+
+ArgoCD is a pure GitOps CD implementation. Outside of content in the
+Application manifests, resources must be available in a git repository.
+
+This repository seeks to include generic manifests that can be applied in any
+environment, and does not include site-local configuration or secrets.
+
+You'll need to create your own private fork of https://github.com/rainest/openchami-kustomize-local
+to hold your overlay.
+
+In your fork:
+
+1. Change `remote/services/app.yaml` and `remote/test-node/app.yaml` to use
+   your fork in `spec.source.repoURL`.
+1. Edit `remote/services/kustomization.yaml` to set your DB passwords
+   under the `secretGenerator` section.
+1. Edit `remote/test-node/userdata` to set an SSH key and hashed password for
+   the virtual machine.
+
+Create a deploy key (for [GitLab](https://docs.gitlab.com/user/project/deploy_keys/)
+or [GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys))
+and configure Argo to use it
+
+```
+argocd repo add https://github.com/myuser/myfork --username myuser ----ssh-private-key-path /path/to/key
+```
+
+### Create applications
+
+From your fork checkout directory:
+
+```
+kubectl apply -n argocd -f test-node/app.yaml
+kubectl apply -n argocd -f services/app.yaml
+```
+
+### Deploy the virtual machine
+
+The `virt-env` Application deploys KubeVirt, a virtual machine (`fred`), an SSH
+access Service, and a [Redfish emulator](https://github.com/rainest/kubevirtbmc)
+that can interact with KubeVirt power control.
+
+There's a remaining rough edge deploying KubeVirt that requires a workaround:
+the KubeVirt operator wants to manage creation of KubeVirt CRDs, and I did not
+find a standalone CRD manifest. This takes a few seconds, and Argo's attempts
+to deploy CRs using those CRDs will fail if run in a single sync.
+
+Although the Application does deploy the VirtualMachine resource in a
+[wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) after
+the operator, there's no guarantee the operator will have deployed the CRDs
+first. There's also often a delay before CRD webhooks are ready.
+
+Allowing retries gets past this pending some better means of blocking on CRD
+availability:
+
+```
+argocd app sync --retry-limit 2 argocd/virt-env
+```
+
+#### Accessing the VM
+
+The virtual machine will take a while to become ready, as it needs to download
+its disk image first. It will eventually transition to `Running`:
+
+```
+15:03:00-0700 baqytgul $ kubectl get virtualmachine
+NAME   AGE    STATUS               READY
+fred   115s   ErrorUnschedulable   False
+```
+
+When the VM reaches `Running`, you can SSH into it using the key you set in
+the `userdata` file:
+
+```
+VM=$(kubectl get svc sshvm -ojson | jq .status.loadBalancer.ingress[0].ip -r); ssh -i /path/to/private/key fred@$VM
+```
+
+Note that KubeVirt does not appeart to re-run cloud-init after initial
+provisioning: while cloud-init docs indicate SSH keys and passwords update on
+each boot, that does _not_ apply to KubeVirt VMs. You must `kubectl delete
+virtualmachine fred` and re-sync the Application if you need to update
+credentials.
+
+#### Interacting with Redfish
+
+These manifests deploy a [modified version](https://github.com/rainest/kubevirtbmc/tree/smd-compat)
+of the [original upstream KubeVirt BMC](https://github.com/starbops/kubevirtbmc/tree/main)
+to support basic auth on all endpoints and to provide power action metdata.
+
+You can change the BMC Service to a LoadBalancer, and then interact with it
+directly via cURL:
+
+```
+kubectl patch svc -n kubevirtbmc-system default-fred-virtbmc -p '{"spec": {"type": "LoadBalancer"}}'
+```
+
+```
+BMC=$(kubectl get svc -n kubevirtbmc-system default-fred-virtbmc -ojson | jq .status.loadBalancer.ingress[0].ip -r); curl -svX POST \
+  -H "Content-Type: application/json" -u admin:password \
+  http://172.19.128.4/redfish/v1/Systems/1/Actions/ComputerSystem.Reset \
+  -d '{"ResetType":"ForceRestart"}'
+```
+
+### Deploying OpenCHAMI
+
+The `openchami` Application deploys [CloudNativePG](https://cloudnative-pg.io/),
+SMD, BSS, and PCS. The service databases will block on CNPG CRD availability
+and need to be synced with retries:
+
+```
+argocd app sync --retry-limit 2 argocd/openchami
+```
+
+#### Adding the machine to SMD
+
+The emulated BMC is unfortunately less complete than proper hardware BMCs, and
+lacks Redfish endpoints that the [OpenCHAMI discovery tool](https://github.com/OpenCHAMI/magellan)
+needs. We can hopefully improve this, but for now it's easiest to manually
+enter machine details.
+
+Released versions of the CLI manual discovery lack support for some information
+that PCS needs. Pending approval and release of
+https://github.com/OpenCHAMI/ochami/pull/47 and https://github.com/OpenCHAMI/ochami/pull/51
+this uses yet another custom build:
+
+```
+go install github.com/rainest/ochami@v0.6.0-beta-pcs
+```
+
+Somewhat amusingly, PCS doesn't actually make use of almost any of the
+information in the fake discovery manifest--it doesn't care about much anything
+other than the xname, and the remaining fields can be entirely garbage:
+
+```
+echo 'nodes:
+-   bmc_ipaddr: 10.49.186.68
+    bmc_fqdn: default-fred-virtbmc.kubevirtbmc-system
+    ipaddr: 10.119.4.198
+    group: dfddfdffdsdf
+    mac: "5e:72:59:e4:6a:a8"
+    name: ba019
+    nid: 1
+    xname: x1000c0s0b0n0
+    interfaces:
+    - mac_addr: f4:a2:2e:ee:9e:f8
+      ip_addrs:
+      - name: internal
+        ip_addr: 10.143.0.199' > /tmp/node.yaml
+```
+
+```
+SMD=$(kubectl get svc -n mgmt smd -ojson | jq .status.loadBalancer.ingress[0].ip -r);
+PCS=$(kubectl get svc -n mgmt pcs -ojson | jq .status.loadBalancer.ingress[0].ip -r);
+echo "default-cluster: bazfoo
+clusters:
+    - name: bazfoo
+      cluster:
+        smd:
+          uri: http://$SMD:27779/hsm/v2/
+        pcs:
+          uri: http://$PCS/v1/" > /tmp/ochami-demo.yaml
+```
+
+Recent additions to skip auth are also not quite in yet, so you'll need a
+pretend credential to use the CLI:
+
+```
+export BAZFOO_ACCESS_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3ODYyMTkxNTZ9.XZ2Imn0IQc5JMmOmsyexESKdc3cHkUMt2suhmymO3RY"
+```
+
+```
+ochami --config /tmp/ochami-demo.yaml -v discover static -f yaml --overwrite -d @/tmp/node.yaml
+```
+
+This will complain about a bad interface address, but it will still create the
+SMD entry the demo needs.
+
+```
+ochami --config /tmp/ochami-demo.yaml smd compep get | jq
+```
+
+will look something like
+
+```
+{
+  "ComponentEndpoints": [
+    {
+      "ComponentEndpointType": "ComponentEndpointComputerSystem",
+      "Enabled": true,
+      "ID": "x1000c0s0b0n0",
+      "OdataID": "/redfish/v1/Systems/x1000c0s0b0n0",
+      "RedfishEndpointFQDN": "x1000c0s0b0",
+      "RedfishEndpointID": "x1000c0s0b0",
+      "RedfishSubtype": "",
+      "RedfishSystemInfo": {
+        "Actions": {
+          "#ComputerSystem.Reset": {
+            "@Redfish.ActionInfo": "/redfish/v1/Systems/x1000c0s0b0n0/ResetActionInfo",
+            "ResetType@Redfish.AllowableValues": [
+              "On",
+              "ForceOff",
+              "GracefulShutdown",
+              "GracefulRestart",
+              "ForceRestart",
+              "Nmi",
+              "ForceOn",
+              "PushPowerButton",
+              "PowerCycle",
+              "Suspend",
+              "Pause",
+              "Resume"
+            ],
+            "target": "/redfish/v1/Systems/x1000c0s0b0n0/Actions/ComputerSystem.Reset"
+          }
+        },
+        "EthernetNICInfo": [
+          {
+            "@odata.id": "",
+            "Description": "Interface 0 for ba019",
+            "InterfaceEnabled": true,
+            "MACAddress": "f4:a2:2e:ee:9e:f8",
+            "RedfishId": ""
+          }
+        ],
+        "Name": "ba019"
+      },
+      "RedfishType": "ComputerSystem",
+      "RedfishURL": "x1000c0s0b0/redfish/v1/Systems/x1000c0s0b0n0",
+      "Type": "Node",
+      "UUID": "fe167d38-a09b-4650-92b3-1abbc2182e14"
+    }
+  ]
+}
+```
+
+#### Initiaing a power transition
+
+The cluster now has everything it needs to handle turning a machine off and on
+again. This doesn't look very exciting from the CLI alone, so you'll want to
+SSH into the VM first to see it in action.
+
+```
+ochami --config /tmp/ochami-demo.yaml pcs transition start --xname "x1000c0s0b0n0" hard-restart
+```
+
+It doesn't look very exciting from within the machine either, but it's at least
+more ready feedback than the CLI provides--PCS actions are asynchronous, so the
+CLI only confirms it's submitted the request, and doesn't know if it'll
+succeed.
+
+You can watch the transition proceed through the CLI, but getting kicked out of
+the machine is more visceral proof:
+
+```
+ochami --config ~/.config/ochami/demo pcs transition monitor f8579afb-2843-417c-9bff-65135c0765a3
+```
+
+However, something's broken re API compatibility and while `transition start`
+works, `transition show` and `transition list` have started 404ing. Pending
+investigation of that, you can check the VM to see that it's restarting:
+
+```
+$ kubectl get virtualmachine
+NAME   AGE   STATUS    READY
+fred   50m   Stopped   False
+
+$ kubectl get virtualmachine
+NAME   AGE   STATUS     READY
+fred   51m   Starting   False
+```

--- a/lbnl/argo/services/bss/base/deployment.yaml
+++ b/lbnl/argo/services/bss/base/deployment.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bss
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: bss
+        image: bss-stub
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 27778
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /boot/v1/service/status
+            port: 27778
+        env:
+        - name: BSS_USESQL
+          value: "true"
+        - name: BSS_INSECURE
+          value: "true"
+        - name: BSS_DBPORT
+          value: "5432"
+        - name: BSS_DBHOST
+          value: ochami-postgres-rw
+        - name: BSS_DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: bss-db
+              key: username
+        - name: BSS_DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: bss-db
+              key: password
+        - name: BSS_DBNAME
+          value: bss
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true

--- a/lbnl/argo/services/bss/base/kustomization.yaml
+++ b/lbnl/argo/services/bss/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: bss
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "30"

--- a/lbnl/argo/services/bss/base/service.yaml
+++ b/lbnl/argo/services/bss/base/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bss
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: http
+      name: bss
+      protocol: TCP

--- a/lbnl/argo/services/bss/db/cnpg.yaml
+++ b/lbnl/argo/services/bss/db/cnpg.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: bss
+spec:
+  name: bss
+  owner: bss
+  cluster:
+    name: ochami-postgres

--- a/lbnl/argo/services/bss/db/kustomization.yaml
+++ b/lbnl/argo/services/bss/db/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cnpg.yaml
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/component: bss
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "15"

--- a/lbnl/argo/services/bss/init/init-job.yaml
+++ b/lbnl/argo/services/bss/init/init-job.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-bss
+spec:
+  template:
+    spec:
+      containers:
+      - name: bss-init
+        image: bss-stub
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/bss-init"]
+        env:
+        - name: BSS_USESQL
+          value: "true"
+        - name: BSS_INSECURE
+          value: "true"
+        - name: BSS_DBPORT
+          value: "5432"
+        - name: BSS_DBHOST
+          value: ochami-postgres-rw
+        - name: BSS_DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: bss-db
+              key: username
+        - name: BSS_DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: bss-db
+              key: password
+        - name: BSS_DBNAME
+          value: bss
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/lbnl/argo/services/bss/init/kustomization.yaml
+++ b/lbnl/argo/services/bss/init/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- init-job.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "20"

--- a/lbnl/argo/services/bss/suite/kustomization.yaml
+++ b/lbnl/argo/services/bss/suite/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mgmt
+
+resources:
+- ../db
+- ../init
+- ../base
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: v1.32.1
+    app.kubernetes.io/component: boot-script-service
+
+images:
+- name: bss-stub
+  newName: ghcr.io/openchami/bss
+  newTag: v1.32.1

--- a/lbnl/argo/services/db/cluster/cluster.yaml
+++ b/lbnl/argo/services/db/cluster/cluster.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ochami-postgres
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  
+  storage:
+    size: 5Gi
+  managed:
+    # Ideally we'd have a way to separate these out without using
+    # separate Clusters per service. They can maybe be patched in?
+    roles:
+    - name: pcs
+      ensure: present
+      comment: power-control
+      login: true
+      superuser: false
+      passwordSecret:
+        name: pcs-db
+      inRoles:
+        - pg_monitor
+        - pg_signal_backend
+    - name: smd
+      ensure: present
+      comment: state-management
+      login: true
+      superuser: false
+      passwordSecret:
+        name: smd-db
+      inRoles:
+        - pg_monitor
+        - pg_signal_backend
+    - name: bss
+      ensure: present
+      comment: boot-script
+      login: true
+      superuser: false
+      passwordSecret:
+        name: bss-db
+      inRoles:
+        - pg_monitor
+        - pg_signal_backend

--- a/lbnl/argo/services/db/cluster/kustomization.yaml
+++ b/lbnl/argo/services/db/cluster/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mgmt
+
+resources:
+- cluster.yaml
+
+# What I wouldn't give for a systemd-esque dependency chain system.
+# Overall, we want the order to be:
+# - 5 CNPG itself
+# - 10 The CNPG Cluster and role Secrets
+# - 15 The Databases
+# - 20 Migration Jobs. Need to think how these will be handled past init
+# - 30 SMD
+# - 35 A static discover Job? Maybe?
+# - 40 Services that aren't SMD
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/lbnl/argo/services/db/cnpg/kustomization.yaml
+++ b/lbnl/argo/services/db/cnpg/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cnpg-system
+
+resources:
+- https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.0.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "5"

--- a/lbnl/argo/services/db/kustomization.yaml
+++ b/lbnl/argo/services/db/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster/
+- cnpg/
+
+# What I wouldn't give for a systemd-esque dependency chain system.
+# Overall, we want the order to be:
+# - 5 CNPG itself
+# - 10 The CNPG Cluster and role Secrets
+# - 15 The Databases
+# - 20 Migration Jobs. Need to think how these will be handled past init
+# - 30 SMD
+# - 35 A static discover Job? Maybe?
+# - 40 Services that aren't SMD

--- a/lbnl/argo/services/namespace/kustomization.yaml
+++ b/lbnl/argo/services/namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ns-mgmt.yaml

--- a/lbnl/argo/services/namespace/ns-mgmt.yaml
+++ b/lbnl/argo/services/namespace/ns-mgmt.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mgmt
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"

--- a/lbnl/argo/services/pcs/base/deployment.yaml
+++ b/lbnl/argo/services/pcs/base/deployment.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pcs
+  labels:
+    app.kubernetes.io/component: power-service
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: 2379,2380
+    spec:
+      containers:
+      - name: pcs
+        image: power-control-stub
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: PCS_FAKE_VAULT_REDFISH_USER
+            value: "admin"
+          - name: PCS_FAKE_VAULT_REDFISH_PASS
+            value: "password"
+          - name: PCS_DEBUG_RFE_PROTO
+            value: "http"
+          - name: PCS_DEBUG_RFE_HOST
+            value: "default-fred-virtbmc"
+          - name: PCS_DEBUG_RFE_DOMAIN
+            value: "kubevirtbmc-system"
+          - name: LOG_LEVEL
+            value: INFO
+          # TODO using the standard port didn't work for whatever reason,
+          # so the SMD Service exposes both 80 and 27779.
+          #- name: SMS_SERVER
+          #  value: http://smd
+          - name: SMS_SERVER
+            value: http://smd:27779
+          - name: VAULT_ENABLED
+            value: "true"
+          - name: VAULT_ADDR
+            value: http://cray-vault.vault:8200
+          - name: VAULT_SKIP_VERIFY
+            value: "true"
+          - name: TRS_IMPLEMENTATION
+            value: LOCAL
+          - name: SERVICE_RESERVATION_VERBOSITY
+            value: ERROR
+          # TODO this appears unused. Dockerfiles have it, but it's absent from code
+          - name: HSMLOCK_ENABLED
+            value: "true"
+          - name: STORAGE
+            value: POSTGRES
+          - name: PCS_CA_URI
+            value: ""
+          - name: MAX_NUM_COMPLETED
+            value: "20000"
+          - name: EXPIRE_TIME_MINS
+            value: "1440"
+          - name: PCS_BASE_TRS_TASK_TIMEOUT
+            value: "40"
+          - name: PCS_STATUS_TIMEOUT
+            value: "30"
+          - name: PCS_STATUS_HTTP_RETRIES
+            value: "3"
+          - name: PCS_MAX_IDLE_CONNS
+            value: "4000"
+          - name: PCS_MAX_IDLE_CONNS_PER_HOST
+            value: "4"
+          - name: MAX_TRANSITION_MESSAGE_LENGTH
+            value: "130"
+          - name: POSTGRES_HOST
+            value: ochami-postgres-rw
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: pcs-db
+                key: username
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pcs-db
+                key: password
+          - name: POSTGRES_DBNAME
+            value: pcs
+          - name: POSTGRES_INSECURE
+            value: "true"
+        ports:
+          - containerPort: 28007
+            name: http
+        livenessProbe:
+          httpGet:
+            path: /v1/liveness
+            port: 28007
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /v1/readiness
+            port: 28007
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 25
+        # TODO we should add cert-manager integration, but don't
+        # currently have it set up.
+        #volumeMounts:
+        #  - mountPath: /usr/local/pki
+        #    name: ochami-pki-cacert-vol
+        resources:
+          limits:
+            cpu: "4"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 256Mi
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+      # TODO we should add cert-manager integration, but don't
+      # currently have it set up.
+      #volumes:
+      #  - configMap:
+      #      name: ochami-configmap-ca-public-key
+      #    name: ochami-pki-cacert-vol

--- a/lbnl/argo/services/pcs/base/kustomization.yaml
+++ b/lbnl/argo/services/pcs/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: pcs
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "30"

--- a/lbnl/argo/services/pcs/base/service.yaml
+++ b/lbnl/argo/services/pcs/base/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pcs
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+      protocol: TCP

--- a/lbnl/argo/services/pcs/db/cnpg.yaml
+++ b/lbnl/argo/services/pcs/db/cnpg.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: pcs
+spec:
+  name: pcs
+  owner: pcs
+  cluster:
+    # TODO https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/nameprefix/ is maybe of interest
+    # for emulating Helm chart release names, but unlike Helm we have no way to make this a function, and
+    # IDK if Kustomize has any good mechanism for "prepend the prefix to this non-name field".
+    name: ochami-postgres

--- a/lbnl/argo/services/pcs/db/kustomization.yaml
+++ b/lbnl/argo/services/pcs/db/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cnpg.yaml
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/component: pcs
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "15"

--- a/lbnl/argo/services/pcs/init/init-job.yaml
+++ b/lbnl/argo/services/pcs/init/init-job.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-pcs
+spec:
+  template:
+    metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: 2379,2380
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: ochami-power-control
+        image: power-control-stub
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: LOG_LEVEL
+            value: INFO
+          - name: STORAGE
+            value: POSTGRES
+          - name: POSTGRES_HOST
+            value: ochami-postgres-rw
+          # TODO it'd be nice to be able to push these down from the suite. can we patch them in
+          # or replace them? Probably simpler to just require a namespace per full deployment and
+          # not worry about name collisions
+          - name: POSTGRES_DBNAME
+            value: pcs
+          - name: POSTGRES_INSECURE
+            value: "true"
+          - name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: pcs-db
+                key: username
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pcs-db
+                key: password
+        command:
+          - power-control
+          - init-postgres
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true

--- a/lbnl/argo/services/pcs/init/kustomization.yaml
+++ b/lbnl/argo/services/pcs/init/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- init-job.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "20"

--- a/lbnl/argo/services/pcs/suite/kustomization.yaml
+++ b/lbnl/argo/services/pcs/suite/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mgmt
+
+resources:
+- ../db
+- ../init
+- ../base
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: v2.7.0
+    app.kubernetes.io/component: power-service
+
+#images:
+#- name: power-control-stub
+#  # TODO there isn't yet a release of Postgres-capable PCS,
+#  # and we furthermore need additional changes to support
+#  # - Using universal BMC creds from the environment, without Vault.
+#  # - Using HTTP for BMC requests.
+#  # - Overriding BMC hostnames. https://github.com/OpenCHAMI/ochami/pull/51
+#  #   resolves this, but isn't released yet.
+#  newName: docker.io/traines/power-control
+#  newTag: v1.1.0-debug.1

--- a/lbnl/argo/services/smd/base/deployment.yaml
+++ b/lbnl/argo/services/smd/base/deployment.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smd
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: smd
+          image: smd-stub
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 27779
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /hsm/v2/service/ready
+              port: 27779
+          env:
+          - name: SMD_DBPORT
+            value: "5432"
+          - name: SMD_DBOPTS
+            value: sslmode=disable
+          - name: SMD_DBHOST
+            value: ochami-postgres-rw
+          - name: SMD_DBUSER
+            valueFrom:
+              secretKeyRef:
+                name: smd-db
+                key: username
+          - name: SMD_DBPASS
+            valueFrom:
+              secretKeyRef:
+                name: smd-db
+                key: password
+          - name: SMD_DBNAME
+            value: smd
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true

--- a/lbnl/argo/services/smd/base/kustomization.yaml
+++ b/lbnl/argo/services/smd/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: smd
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "30"

--- a/lbnl/argo/services/smd/base/service.yaml
+++ b/lbnl/argo/services/smd/base/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smd
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: http
+      name: smd
+      protocol: TCP
+    # TODO no idea why, but the named target via the default HTTP port
+    # was quite unhappy, so exposing both and configuring other services
+    # to use the original SMD API port.
+    - port: 27779
+      targetPort: 27779
+      name: smd-alt
+      protocol: TCP

--- a/lbnl/argo/services/smd/db/cnpg.yaml
+++ b/lbnl/argo/services/smd/db/cnpg.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: smd
+spec:
+  name: smd
+  owner: smd
+  cluster:
+    name: ochami-postgres

--- a/lbnl/argo/services/smd/db/kustomization.yaml
+++ b/lbnl/argo/services/smd/db/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cnpg.yaml
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/component: smd
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "15"

--- a/lbnl/argo/services/smd/init/init-job.yaml
+++ b/lbnl/argo/services/smd/init/init-job.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-smd
+spec:
+  template:
+    spec:
+      containers:
+        - name: smd-init
+          image: smd-stub
+          imagePullPolicy: IfNotPresent
+          command: ["/smd-init"]
+          env:
+          - name: SMD_DBPORT
+            value: "5432"
+          - name: SMD_DBOPTS
+            value: sslmode=disable
+          - name: SMD_DBHOST
+            value: ochami-postgres-rw
+          - name: SMD_DBUSER
+            valueFrom:
+              secretKeyRef:
+                name: smd-db
+                key: username
+          - name: SMD_DBPASS
+            valueFrom:
+              secretKeyRef:
+                name: smd-db
+                key: password
+          - name: SMD_DBNAME
+            value: smd
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/lbnl/argo/services/smd/init/kustomization.yaml
+++ b/lbnl/argo/services/smd/init/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- init-job.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "20"

--- a/lbnl/argo/services/smd/suite/kustomization.yaml
+++ b/lbnl/argo/services/smd/suite/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mgmt
+
+resources:
+- ../db
+- ../init
+- ../base
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: v2.18.0
+    app.kubernetes.io/component: state-manager
+
+images:
+- name: smd-stub
+  newName: docker.io/traines/smd
+  newTag: v2.0.2-debug.4

--- a/lbnl/argo/services/suite/app.yaml
+++ b/lbnl/argo/services/suite/app.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openchami
+spec:
+  project: default
+  syncPolicy:
+    syncOptions:
+    - ServerSideApply=true
+    - SkipDryRunOnMissingResource=true
+  source:
+    path: 'lbnl/argo/services/suite'
+    repoURL: 'https://github.com/OpenCHAMI/deployment-recipes/"
+    targetRevision: 2025-08-21
+  destination:
+    namespace: mgmt
+    server: 'https://kubernetes.default.svc'

--- a/lbnl/argo/services/suite/kustomization.yaml
+++ b/lbnl/argo/services/suite/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../db
+- ../smd/suite
+- ../bss/suite
+- ../pcs/suite
+
+# TODO this probably should be handled at the ochami/suite level, since that's where other end
+# user modification happens. However, that precludes doing an earlier replacement in ochami/pcs/suite:
+# image overrides build from the bottom up, and if your included resource includes a replace, your
+# including kustomization needs to match the result of the replace, not the original stub. Top-level
+# image sections do not clobber lower-level ones.
+#
+# This means you can't deploy ochami/pcs independently without modifying its kustomization. It'd be
+# nice if you could render either with a valid image using the stock manifests.
+images:
+- name: power-control-stub
+  newName: docker.io/traines/power-control
+  newTag: v1.1.0-debug.14444

--- a/lbnl/argo/test-node/kubevirt/base/kustomization.yaml
+++ b/lbnl/argo/test-node/kubevirt/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/kubevirt/kubevirt/releases/download/v1.6.0/kubevirt-operator.yaml
+- https://github.com/kubevirt/kubevirt/releases/download/v1.6.0/kubevirt-cr.yaml 
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "1"

--- a/lbnl/argo/test-node/kubevirt/cdi/kustomization.yaml
+++ b/lbnl/argo/test-node/kubevirt/cdi/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.62.0/cdi-operator.yaml
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.62.0/cdi-cr.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "2"

--- a/lbnl/argo/test-node/kubevirt/kustomization.yaml
+++ b/lbnl/argo/test-node/kubevirt/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./base
+- ./cdi
+
+labels:
+- includeSelectors: false
+  pairs:
+    virtfish.example/component: kubevirt

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/.helmignore
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/Chart.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: v0.5.3
+description: A Helm chart for KubeVirtBMC
+home: https://github.com/starbops/kubevirtbmc
+keywords:
+- Kubernetes
+- KubeVirt
+- IPMI
+- Redfish
+maintainers:
+- email: starbops@hey.com
+  name: starbops
+  url: https://www.zespre.com
+name: kubevirtbmc
+sources:
+- https://github.com/starbops/kubevirtbmc
+type: application
+version: 0.2.4

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/crds/virtualmachine.kubevirt.io_virtualmachinebmcs.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/crds/virtualmachine.kubevirt.io_virtualmachinebmcs.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubevirtbmc-system/kubevirtbmc-serving-cert
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: virtualmachinebmcs.virtualmachine.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: virtualmachine.kubevirt.io
+  names:
+    kind: VirtualMachineBMC
+    listKind: VirtualMachineBMCList
+    plural: virtualmachinebmcs
+    singular: virtualmachinebmc
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineBMC is the Schema for the virtualmachinebmcs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineBMCSpec defines the desired state of VirtualMachineBMC
+            properties:
+              password:
+                description: The credential part of the IPMI service
+                type: string
+              username:
+                description: To authenticate who the user is.
+                type: string
+              vmName:
+                description: The actual virtual machine that this BMC controls
+                type: string
+              vmNamespace:
+                description: The namespace where the virtual machine is in
+                type: string
+            required:
+            - vmName
+            - vmNamespace
+            type: object
+          status:
+            description: VirtualMachineBMCStatus defines the observed state of VirtualMachineBMC
+            properties:
+              ready:
+                description: The indicator that shows the readiness of the IPMI service
+                  for the virtual machine
+                type: boolean
+              serviceIP:
+                description: The listen IP address for the IPMI service.
+                type: string
+            required:
+            - ready
+            - serviceIP
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/NOTES.txt
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/NOTES.txt
@@ -1,0 +1,1 @@
+KubeVirtBMC is installed successfully. You can now create virtual machines with BMC support.

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/_helpers.tpl
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/certificate.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/certificate.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: {{ include "chart.name" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: {{ include "chart.name" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ include "chart.name" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ include "chart.name" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "chart.name" . }}-selfsigned-issuer
+  secretName: {{ include "chart.name" . }}-webhook-server-cert

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/deployment.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+        kubectl.kubernetes.io/default-container: manager
+      {{- end }}
+      labels:
+        {{- include "chart.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/component: manager
+        app.kubernetes.io/part-of: {{ include "chart.name" . }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}-manager
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: manager
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        ports:
+        - name: metrics-server
+          containerPort: 8080
+          protocol: TCP
+        - name: webhook-server
+          containerPort: 9443
+          protocol: TCP
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        volumeMounts:
+        - name: cert
+          mountPath: "/tmp/k8s-webhook-server/serving-certs"
+          readOnly: true
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      volumes:
+      - name: cert
+        secret:
+          secretName: {{ include "chart.name" . }}-webhook-server-cert
+          defaultMode: 420
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/hpa.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/rbac.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/rbac.yaml
@@ -1,0 +1,308 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-vm-watcher
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-pod-svc-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-vmbmc-manager
+rules:
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-vm-manager
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: {{ include "chart.name" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-watch-vms
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chart.name" . }}-vm-watcher
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chart.name" . }}-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-manage-pods-svcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chart.name" . }}-pod-svc-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-manage-vmbmcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chart.name" . }}-vmbmc-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: virtbmc-rolebinding
+    app.kubernetes.io/component: virtbmc-rbac
+    app.kubernetes.io/created-by: kubevirtbmc
+    app.kubernetes.io/part-of: kubevirtbmc
+    app.kubernetes.io/managed-by: kustomize
+  name: virtbmc-rolebinding
+
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-manage-vm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chart.name" . }}-vm-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-virtbmc
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: {{ include "chart.name" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "chart.name" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/service.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: {{ .Values.service.metricsPort }}
+    protocol: TCP
+    targetPort: metrics-server
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: {{ include "chart.name" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: {{ .Values.service.webhookPort }}
+    protocol: TCP
+    targetPort: webhook-server
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 6 }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/serviceaccount.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/serviceaccount.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}-virtbmc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/servicemonitor.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  name: {{ include "chart.name" . }}-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - path: /metrics
+    port: https
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/webhoookconfiguration.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/templates/webhoookconfiguration.yaml
@@ -1,0 +1,63 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "chart.name" . }}-serving-cert
+  name: {{ include "chart.name" . }}-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "chart.name" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-virtualmachine-kubevirt-io-v1alpha1-virtualmachinebmc
+  failurePolicy: Fail
+  name: mvirtualmachinebmc.kb.io
+  rules:
+  - apiGroups:
+    - virtualmachine.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinebmcs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "chart.name" . }}-serving-cert
+  name: {{ include "chart.name" . }}-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "chart.name" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-virtualmachine-kubevirt-io-v1alpha1-virtualmachinebmc
+  failurePolicy: Fail
+  name: vvirtualmachinebmc.kb.io
+  rules:
+  - apiGroups:
+    - virtualmachine.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinebmcs
+  sideEffects: None

--- a/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/values.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/charts/kubevirtbmc-v0.2.4/kubevirtbmc/values.yaml
@@ -1,0 +1,120 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: starbops/virtbmc-controller
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+kubeRbacProxy:
+  image:
+    # This is the image used by kube-proxy.
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    # This sets the pull policy for images.
+    pullPolicy: IfNotPresent
+    tag: v0.15.0
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - "ALL"
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  metricsPort: 8443
+  webhookPort: 443
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceMonitor:
+  create: false

--- a/lbnl/argo/test-node/kubevirtbmc/kustomization.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubevirtbmc-system
+
+resources:
+- vbmc.yaml
+- virtualmachine.kubevirt.io_virtualmachinebmcs.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "4"

--- a/lbnl/argo/test-node/kubevirtbmc/vbmc.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/vbmc.yaml
@@ -1,0 +1,665 @@
+# Originally attempted to use the Helm Kustomize invocation:
+#
+#HelmCharts:
+#- name: kubevirtbmc
+#  includeCRDs: true
+#  valuesInline: {}
+#  releaseName: bmc
+#  version: v0.2.4
+#  repo: https://charts.zespre.com/
+#
+# However, that broke:
+# Error: map[string]interface {}(nil): yaml: unmarshal errors:
+#   line 13: mapping key "labels" already defined at line 5
+# so this contains "helm template" output with some changes.
+---
+# Source: kubevirtbmc/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+automountServiceAccountToken: true
+---
+# Source: kubevirtbmc/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirtbmc-virtbmc
+  namespace: kubevirtbmc-system
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+automountServiceAccountToken: true
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-vm-watcher
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-pod-svc-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-vmbmc-manager
+rules:
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - virtualmachine.kubevirt.io
+  resources:
+  - virtualmachinebmcs/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: agent-rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-vm-manager
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-watch-vms
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirtbmc-vm-watcher
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirtbmc-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-manage-pods-svcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirtbmc-pod-svc-manager
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-manage-vmbmcs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirtbmc-vmbmc-manager
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: virtbmc-rolebinding
+    app.kubernetes.io/component: virtbmc-rbac
+    app.kubernetes.io/created-by: kubevirtbmc
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: virtbmc-rolebinding
+# TODO something's screwy with the chart and it inserts two labels/name fields here
+# IDK which one is correct
+#
+#  labels:
+#    helm.sh/chart: kubevirtbmc-0.2.4
+#    app.kubernetes.io/name: kubevirtbmc
+#    app.kubernetes.io/instance: kubevirtbmc
+#    app.kubernetes.io/version: "v0.5.3"
+#    app.kubernetes.io/component: agent-rbac
+#    app.kubernetes.io/part-of: kubevirtbmc
+#  name: kubevirtbmc-manage-vm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirtbmc-vm-manager
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-virtbmc
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-leader-election-role
+  namespace: kubevirtbmc-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: kubevirtbmc/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-leader-election-rolebinding
+  namespace: kubevirtbmc-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirtbmc-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kubevirtbmc-manager
+  namespace: kubevirtbmc-system
+---
+# Source: kubevirtbmc/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-metrics-service
+  namespace: kubevirtbmc-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: metrics-server
+  selector:
+      app.kubernetes.io/name: kubevirtbmc
+      app.kubernetes.io/instance: kubevirtbmc
+---
+# Source: kubevirtbmc/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-webhook-service
+  namespace: kubevirtbmc-system
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: webhook-server
+  selector:
+      app.kubernetes.io/name: kubevirtbmc
+      app.kubernetes.io/instance: kubevirtbmc
+---
+# Source: kubevirtbmc/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubevirtbmc
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/part-of: kubevirtbmc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubevirtbmc
+      app.kubernetes.io/instance: kubevirtbmc
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: kubevirtbmc-0.2.4
+        app.kubernetes.io/name: kubevirtbmc
+        app.kubernetes.io/instance: kubevirtbmc
+        app.kubernetes.io/version: "v0.5.3"
+        app.kubernetes.io/component: manager
+        app.kubernetes.io/part-of: kubevirtbmc
+    spec:
+      serviceAccountName: kubevirtbmc-manager
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: manager
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+        image: "traines/virtbmc-controller:v0.5.3-ainfo"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--agent-image-name=traines/virtbmc"
+        - "--agent-image-tag=v0.5.3-ainfo.3"
+        - "--leader-elect"
+        ports:
+        - name: metrics-server
+          containerPort: 8080
+          protocol: TCP
+        - name: webhook-server
+          containerPort: 9443
+          protocol: TCP
+        livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+        readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+        resources:
+            {}
+        volumeMounts:
+        - name: cert
+          mountPath: "/tmp/k8s-webhook-server/serving-certs"
+          readOnly: true
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image: "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      volumes:
+      - name: cert
+        secret:
+          secretName: kubevirtbmc-webhook-server-cert
+          defaultMode: 420
+---
+# Source: kubevirtbmc/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-serving-cert
+  namespace: kubevirtbmc-system
+spec:
+  dnsNames:
+  - kubevirtbmc-webhook-service.kubevirtbmc-system.svc
+  - kubevirtbmc-webhook-service.kubevirtbmc-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: kubevirtbmc-selfsigned-issuer
+  secretName: kubevirtbmc-webhook-server-cert
+---
+# Source: kubevirtbmc/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/part-of: kubevirtbmc
+  name: kubevirtbmc-selfsigned-issuer
+  namespace: kubevirtbmc-system
+spec:
+  selfSigned: {}
+---
+# Source: kubevirtbmc/templates/webhoookconfiguration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: kubevirtbmc
+  annotations:
+    cert-manager.io/inject-ca-from: kubevirtbmc-system/kubevirtbmc-serving-cert
+  name: kubevirtbmc-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kubevirtbmc-webhook-service
+      namespace: kubevirtbmc-system
+      path: /mutate-virtualmachine-kubevirt-io-v1alpha1-virtualmachinebmc
+  failurePolicy: Fail
+  name: mvirtualmachinebmc.kb.io
+  rules:
+  - apiGroups:
+    - virtualmachine.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinebmcs
+  sideEffects: None
+---
+# Source: kubevirtbmc/templates/webhoookconfiguration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: kubevirtbmc-0.2.4
+    app.kubernetes.io/name: kubevirtbmc
+    app.kubernetes.io/instance: kubevirtbmc
+    app.kubernetes.io/version: "v0.5.3"
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/part-of: kubevirtbmc
+  annotations:
+    cert-manager.io/inject-ca-from: kubevirtbmc-system/kubevirtbmc-serving-cert
+  name: kubevirtbmc-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kubevirtbmc-webhook-service
+      namespace: kubevirtbmc-system
+      path: /validate-virtualmachine-kubevirt-io-v1alpha1-virtualmachinebmc
+  failurePolicy: Fail
+  name: vvirtualmachinebmc.kb.io
+  rules:
+  - apiGroups:
+    - virtualmachine.kubevirt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachinebmcs
+  sideEffects: None

--- a/lbnl/argo/test-node/kubevirtbmc/virtualmachine.kubevirt.io_virtualmachinebmcs.yaml
+++ b/lbnl/argo/test-node/kubevirtbmc/virtualmachine.kubevirt.io_virtualmachinebmcs.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubevirtbmc-system/kubevirtbmc-serving-cert
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: virtualmachinebmcs.virtualmachine.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: virtualmachine.kubevirt.io
+  names:
+    kind: VirtualMachineBMC
+    listKind: VirtualMachineBMCList
+    plural: virtualmachinebmcs
+    singular: virtualmachinebmc
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachineBMC is the Schema for the virtualmachinebmcs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineBMCSpec defines the desired state of VirtualMachineBMC
+            properties:
+              password:
+                description: The credential part of the IPMI service
+                type: string
+              username:
+                description: To authenticate who the user is.
+                type: string
+              vmName:
+                description: The actual virtual machine that this BMC controls
+                type: string
+              vmNamespace:
+                description: The namespace where the virtual machine is in
+                type: string
+            required:
+            - vmName
+            - vmNamespace
+            type: object
+          status:
+            description: VirtualMachineBMCStatus defines the observed state of VirtualMachineBMC
+            properties:
+              ready:
+                description: The indicator that shows the readiness of the IPMI service
+                  for the virtual machine
+                type: boolean
+              serviceIP:
+                description: The listen IP address for the IPMI service.
+                type: string
+            required:
+            - ready
+            - serviceIP
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/lbnl/argo/test-node/kustomization.yaml
+++ b/lbnl/argo/test-node/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- ../db
+- ../smd/suite
+- ../bss/suite
+- ../pcs/suite
+
+# TODO this probably should be handled at the ochami/suite level, since that's where other end
+# user modification happens. However, that precludes doing an earlier replacement in ochami/pcs/suite:
+# image overrides build from the bottom up, and if your included resource includes a replace, your
+# including kustomization needs to match the result of the replace, not the original stub. Top-level
+# image sections do not clobber lower-level ones.
+#
+# This means you can't deploy ochami/pcs independently without modifying its kustomization. It'd be
+# nice if you could render either with a valid image using the stock manifests.
+images:
+- name: power-control-stub
+  newName: docker.io/traines/power-control
+  newTag: v1.1.0-debug.14444

--- a/lbnl/argo/test-node/namespace/kustomization.yaml
+++ b/lbnl/argo/test-node/namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ns-kubevirtbmc.yaml

--- a/lbnl/argo/test-node/namespace/ns-kubevirtbmc.yaml
+++ b/lbnl/argo/test-node/namespace/ns-kubevirtbmc.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirtbmc-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/lbnl/argo/test-node/suite/app.yaml
+++ b/lbnl/argo/test-node/suite/app.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: virt-env
+spec:
+  project: default
+  syncPolicy:
+    syncOptions:
+    - ServerSideApply=true
+    - SkipDryRunOnMissingResource=true
+  source:
+    path: 'lbnl/argo/test-vm/suite'
+    repoURL: 'https://github.com/OpenCHAMI/deployment-recipes/'
+    targetRevision: main
+  destination:
+    server: 'https://kubernetes.default.svc'

--- a/lbnl/argo/test-node/suite/kustomization.yaml
+++ b/lbnl/argo/test-node/suite/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../kubevirt
+- ../kubevirtbmc
+- ../vm
+# TODO installing cert-manager using Argo makes Argo unhappy with webhook certs.
+# unknown issue prevents Argo from trusting cert-manager's. Pending a fix for that,
+# it must be installed separately:
+#
+# kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/part-of: virt-test

--- a/lbnl/argo/test-node/vm/bmc.yaml
+++ b/lbnl/argo/test-node/vm/bmc.yaml
@@ -1,0 +1,22 @@
+# TODO This relies on static mapping between the VM and this resource.
+# Ideally, the kustomization should patch the VM name to both the VM and BMC.
+apiVersion: virtualmachine.kubevirt.io/v1alpha1
+kind: VirtualMachineBMC
+metadata:
+  labels:
+    app.kubernetes.io/name: virtualmachinebmc
+    app.kubernetes.io/instance: fred
+    app.kubernetes.io/part-of: kubevirtbmc
+    app.kubernetes.io/created-by: kubevirtbmc
+  name: fred-bmc
+  # TODO Not sure if these are actually limited to the system namespace.
+  # The examples are, but that with a remote NS reference feels backwards.
+  # In initial testing I didn't see the operator provision others and just
+  # used the default one. It'd be nice to have these expose xnames along the
+  # default SMD expectations.
+  namespace: kubevirtbmc-system
+spec:
+  username: admin
+  password: fredfred
+  vmNamespace: default
+  vmName: fred

--- a/lbnl/argo/test-node/vm/dv_fedora.yaml
+++ b/lbnl/argo/test-node/vm/dv_fedora.yaml
@@ -1,0 +1,16 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "fedora"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+  source:
+    http:
+      url: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-AmazonEC2-42-1.1.x86_64.raw.xz"

--- a/lbnl/argo/test-node/vm/kustomization.yaml
+++ b/lbnl/argo/test-node/vm/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+resources:
+- vm.yaml
+- dv_fedora.yaml
+- bmc.yaml
+
+labels:
+- includeSelectors: false
+  pairs:
+    virtfish.example/component: vm
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "5"

--- a/lbnl/argo/test-node/vm/ochami-node.yaml
+++ b/lbnl/argo/test-node/vm/ochami-node.yaml
@@ -1,0 +1,27 @@
+nodes:
+-   name: ba011
+    # We'd need static IP configuration on the VM and BMC to make these meaningful.
+    # I'm not sure where they're actually used outside of coresmd DHCP configuration,
+    # which is irrelevant for kubevirt.
+    bmc_ipaddr: 10.49.186.68
+    ipaddr: 10.119.4.198
+    # Similarly only relevant to DHCP, but there's likely no way to provide a "correct"
+    # value at all.
+    mac: "5e:72:59:e4:6a:a8"
+    # TODO this depends on the VM name. It uses the BMC kubevirtbmc auto-creates
+    # instead of a custom one. It is not available in the current v0.5.3 release:
+    # https://github.com/OpenCHAMI/ochami/pull/51
+    # PCS _does not_ have the ability to select BMC protocol from SMD configuration,
+    # and still needs PCS_DEBUG_RFE_PROTO to override that to HTTP.
+    bmc_fqdn: default-fred-virtbmc.kubevirtbmc-system
+    group: example
+    nid: 1
+    xname: x1000c0s0b0n0
+    # TODO these are fake values, and PCS at least doesn't appear to care about them.
+    # However, SMD appears to have some odd behavior for static discovered nodes with
+    # no interfaces that still needs investigation.
+    interfaces:
+    - mac_addr: f4:a2:2e:ee:9e:f8
+      ip_addrs:
+      - name: internal
+        ip_addr: 10.143.0.199

--- a/lbnl/argo/test-node/vm/vm.yaml
+++ b/lbnl/argo/test-node/vm/vm.yaml
@@ -1,0 +1,87 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  creationTimestamp: 2018-07-04T15:03:08Z
+  generation: 1
+  labels:
+    kubevirt.io/os: linux
+  # TODO this should be configurable, and ideally we'd have some means of deploying multiple.
+  name: fred
+  annotations:
+    # TODO guides currently have this specified at the Application level. We may want to start
+    # doing it per resource as shown here.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt.io/domain: fred
+    spec:
+      hostname: fred
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: disk0
+          - cdrom:
+              bus: sata
+              readonly: true
+            name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - name: ssh
+                  port: 22
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: default
+        pod: {} # Stock pod network
+      volumes:
+      - name: disk0
+        persistentVolumeClaim:
+          claimName: fedora
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          secretRef:
+            name: vm-cloud-init
+---
+# TODOI I forget exactly why this exists. It's probably unnecessary.
+apiVersion: v1
+kind: Service
+metadata:
+  name: vm
+spec:
+  selector:
+    vm.kubevirt.io/name: fred
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: foo # Actually, no port is needed.
+    port: 1234
+    targetPort: 1234
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # TODO while the SSH service is more useful, at present it's tied to the single VM instance.
+  # Multiple would name collide. We'd either need https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/nameprefix/
+  # in the kustomization or require separate namespaces for each VM.
+  name: sshvm
+spec:
+  selector:
+    vm.kubevirt.io/name: fred
+  type: LoadBalancer
+  ports:
+  - name: ssh
+    port: 22
+    targetPort: 22


### PR DESCRIPTION
Add a set of Kustomize manifests and example ArgoCD Applications for deploying OpenCHAMI management services and a test VM.

This stands up the test environment discussed in https://github.com/OpenCHAMI/ochami/pull/47#issuecomment-3246080005 

My intent is to use this as the main Kubernetes deployment system for OpenCHAMI services and to provision test environments for it, as a more batteries-included Kubernetes-flavored quickstart than we're reasonably able to handle with Helm.

---

Some functionality relies on as-yet unreleased code. We want to eventually get on officially released images, but need this environment to demonstrate that some changes work. In general, we should probably start making nightly and on-demand PR builds available to simplify dealing with that sort of circular review dependency, rather than me custom building something and tossing it on DockerHub.

PCS Postgres support is the only unreleased bit required for the deployments to successfully start. The remaining items are necessary for PCS to talk to KubeVirtBMC.

`ochami discover static` needs to be able to provide power action information and set BMC FQDNs:

https://github.com/OpenCHAMI/ochami/pull/47
https://github.com/OpenCHAMI/ochami/pull/51

PCS needs a unreleased Postgres support and unmerged support for a mock credential store and HTTP BMCs:

https://github.com/OpenCHAMI/power-control/pull/49
https://github.com/OpenCHAMI/power-control/pull/50

The proper alternative to the power-control#50 hack is to either add BMC protocol to the SMD RFE schema or to add HTTPS support to KubeVirtBMC. The latter is doable, but I haven't started it yet.

I believe there are some unreleased changes in SMD also that this relies on. I didn't need to modify SMD, but did build a custom image off the tip of main sometime in 2025-08.