### PR TITLE
Add RHEL10 support framework

### DIFF
--- a/dell/podman-quadlets/README.md
+++ b/dell/podman-quadlets/README.md
@@ -1,0 +1,322 @@
+# OpenCHAMI with Podman Quadlets
+This Doc is a very brief tutorial on how to deploy OpenCHAMI with the podman-quadlets recipe.  
+This won't get a full production system running but should give you an idea of how to get started in that direction.
+
+## Assumptions
+
+### A running OS
+I think we all know how to install a linux OS on a machine at this point.
+This has been currently tested on RHEL10.0 and it's cousins. 
+
+### Config Management
+We'll go over some config management, but it will not be a full system deployment. Anything beyond basic booting functions will not be covered
+
+### Cluster Images
+OpenCHAMI doesn't provide an image build system. It relies on external images being available.  
+We'll go over how we are building images locally but they won't be full production-like images
+
+## Prep
+Some stuff we need before we start deploying OpenCHAMI
+
+### Package installs
+```bash
+dnf install -y ansible-core git podman jq
+ansible-galaxy collection install community.general
+ansible-galaxy collection install ansible.posix
+pip3 install jmespath
+```
+
+### Setup hosts
+Clusters generally have names. This cluster is named `demo` and the shortname for our nodes is `nid`. Feel free to be creative on your own time.  
+The BMCs are named `<shortname>-bmc`. 
+Make your `/etc/hosts` look something like
+```bash
+172.16.0.254    demo.openchami.cluster
+172.16.0.1      nid001
+172.16.0.2      nid002
+172.16.0.3      nid003
+172.16.0.4      nid004
+172.16.0.5      nid005
+172.16.0.6      nid006
+172.16.0.7      nid007
+172.16.0.8      nid008
+172.16.0.9      nid009
+172.16.0.101    nid-bmc001
+172.16.0.102    nid-bmc002
+172.16.0.103    nid-bmc003
+172.16.0.104    nid-bmc004
+172.16.0.105    nid-bmc005
+172.16.0.106    nid-bmc006
+172.16.0.107    nid-bmc007
+172.16.0.108    nid-bmc008
+172.16.0.109    nid-bmc009
+```
+
+## OpenCHAMI microservices
+OpenCHAMI is a long acronym for something that is probably a lot more simple than you would expect. OpenCHAMI is ostensibly based on CSM but really we took SMD and BSS and that's about it. 
+
+### SMD
+State Management Database (SMD), at least that is what I think SMD stands for, is a set of APIs that sit in front of a Postgres database. SMD does a lot more in CSM than it does in OpenCHAMI. There is no hardware discovery happening in SMD and we don't use it for holding the state of anything. SMD is simply an API that talks to a database that holds component information. The components here are Nodes, BMCs, and Interface data. 
+In OpenCHAMI SMD does not actively do anything and is a repository of information on the system hardware. 
+### BSS
+BootScript Service (BSS) is a service that provides on demand iPXE scripts to nodes during the netboot process. It talks to SMD to confirm the requesting node exists and if so it returns a generated iPXE script based on the data it holds about that node. 
+### Cloud-init
+We wrote a custom cloud-init server that does some things similar to BSS. It will process the requesting nodes IP and find the component and/or group information, then build the cloud-init configs from there. Cloud-init data is populated externally. OpenCHAMI does not provide the actual configs only a way to push out the configs. 
+
+### opaal and Hydra
+#### Hydra
+[Hydra](https://github.com/ory/hydra) is an oauth provider but it does not manage logins or user accounts etc. We use Hydra to create and hand out JWTs.
+
+### opaal
+Opaal is a toy OIDC provider. You make a request to opaal and it makes a JWT request to hydra, then hands that back to the "user". It's a pretend login service.
+
+Hydra is something that will probably stick around for a while as we use it as the authorization server. opaal is a stand in service that will probably get replaced, hopefully soon.
+So I wouldn't worry too much about opaal.
+### ACME and step-ca
+Automatic Certificate Management Environemnt or ACME is what we use to automate CA cert renewals. This is so you don't have that special day every year when all your certificates expire and you have to go renew them and it's annoying. Now you have to renew them everyday! but it should be "automatic" and much easier. I say that but we only issue a single cert at the moment, so time will tell. We use [acme.sh](https://github.com/acmesh-official/acme.sh) to generate certs from a certificate authority. 
+
+[step-ca](https://smallstep.com/docs/step-ca/) is the certificate authority we use to generate CA certs. 
+### haproxy
+HAproxy acts our API gateway. It's what allows outside requests to reach into the container network and talk to various OpenCHAMI services. 
+### postgres
+We use postgres as the backend for BSS, SMD, and Hydra. It's just a postgres database in a container. 
+
+## OpenCHAMI adjacent techonologies
+OpenCHAMI doesn't exist in a vacuum. There are parts of deploying OpenCHAMI that are not managed by OpenCHAMI. 
+We'll cover some of these briefly. Very Briefly. 
+
+### DHCP and iPXE and Dracut
+These are all important parts of the boot process. 
+
+#### DHCP
+DHCP is all over the place so I'm not gonna go over what DHCP is. OpenCHAMI provides a [CoreDHCP](https://github.com/coredhcp/coredhcp) plugin called [coresmd](https://github.com/OpenCHAMI/coresmd). This links up with SMD to build out the config files and also provides TFTP based on the nodes architecture. This allows us to boot many types of systems.
+
+#### iPXE
+iPXE is also something we should all be familiar with. OpenCHAMI interacts with iPXE via BSS, as explained above, but does not control the entire workflow.
+
+We continue to use iPXE because it is in all firmware at this point. HTTP booting is becoming more popular but not all vendors are building that into their firmware just yet. 
+
+#### Dracut
+OpenCHAMI doesn't directly interact with the dracut init stage, but we can insert parameters into BSS that can have an effect here. 
+One example is NFS provided rootfs. 
+
+## Deploying OpenCHAMI  
+First pull down the deployment-recipes repo from the OpenCHAMI GitHub.
+```bash
+git clone https://github.com/OpenCHAMI/deployment-recipes.git
+```
+Go to the cloned repo and the LANL podman-quadlets recipes
+```bash
+cd deployment-recipes/dell/podman-quadlets
+```
+Here will have to make some local changes that match your system
+
+### Setup the inventory
+The inventory is a single node so just change `inventory/01-ochami` and set
+```ini
+[ochami]
+localhost ansible_connection=local
+```
+To be the value of `hostname` (demo-head.si.usrc in this case).
+
+### Set cluster names
+Update below variables in `inventory/group_vars/ochami/cluster.yaml` as per your cluster and requirements.
+```yaml
+cluster_name: "demo"
+cluster_shortname: "nid"
+cluster_nidlength: 3
+cluster_domain: "openchami.cluster"
+cluster_boot_ip: 172.16.0.254
+cluster_boot_interface: ens259f0
+rhel_tag: 10.0
+rhel_repos:
+  - { name: 'RHEL10_BaseOS', url: '', gpg: '' }
+  - { name: 'RHEL10_AppStream', url: '', gpg: '' }
+```
+
+### Update the dhcp configuration
+Update netmask and dhcp dynamic range in `inventory/group_vars/ochami/coredhp.yaml` as per your cluster.
+```yaml
+coredhcp_netmask: '255.255.255.0'
+coredhcp_dhcp_pool: '172.16.0.200 172.16.0.250'
+```
+### Populate nodes
+Now we need to populate `inventory/group_vars/ochami/nodes.yaml`. This describes your cluster in a flat yaml file. 
+It will look something like:
+```yaml
+nodes:
+- name: nid001
+  xname: x1000c1s7b1n0
+  nid: 1
+  group: compute
+  bmc_mac: c2:77:05:e2:03:48
+  bmc_ip: 172.16.0.101
+  interfaces:
+  - mac_addr: ec:e7:a7:05:a1:fc
+    ip_addrs:
+    - name: management
+      ip_addr: 172.16.0.1
+```
+
+### Running the OpenCHAMI playbook
+Almost done. Run the provided playbook:
+```bash
+ansible-playbook -i inventory ochami_playbook.yaml
+```
+
+Should take a minute or two to start everything and populate the services.  
+At the end you should have these containers running:
+```bash
+# podman ps --noheading | awk '{print $NF}' | sort
+bss
+cloud-init-server
+coresmd
+haproxy
+hydra
+image-server
+opaal
+opaal-idp
+postgres
+smd
+step-ca
+```
+
+### Verifying things look OK
+
+Ansible will install a CLI tool called `ochami`.  
+This tool comes with manual pages. See **ochami**(1) for more.
+
+Let's take a look at our config to make sure things are set correctly:
+```bash
+ochami config show
+```
+It should look like this:
+```yaml
+clusters:
+    - cluster:
+        uri: https://demo.openchami.cluster:8443
+      name: demo
+default-cluster: demo
+log:
+    format: basic
+    level: warning
+```
+
+Now, we need to generate a token for the "demo" cluster. `ochami` reads this
+from `<CLUSTER_NAME>_ACCESS_TOKEN` where `<CLUSTER_NAME>` is the configured name
+of the cluster in all capitals. This is `DEMO` in our case. Let's set the token:
+```bash
+export DEMO_ACCESS_TOKEN=$(gen_access_token)
+```
+
+Check SMD is populated with `ochami smd component get | jq`
+```json
+{
+  "Components": [
+    {
+      "Enabled": true,
+      "ID": "x1000c1s7b1",
+      "Type": "Node"
+    },
+    {
+      "Enabled": true,
+      "Flag": "OK",
+      "ID": "x1000c1s7b1n0",
+      "NID": 1,
+      "Role": "Compute",
+      "State": "On",
+      "Type": "Node"
+    },
+    {
+      "Enabled": true,
+      "ID": "x1000c1s7b2",
+      "Type": "Node"
+    },
+    {
+      "Enabled": true,
+      "Flag": "OK",
+      "ID": "x1000c1s7b2n0",
+      "NID": 2,
+      "Role": "Compute",
+      "State": "On",
+      "Type": "Node"
+    },
+    ...
+]
+```
+You should see:
+```json
+    {
+      "Enabled": true,
+      "ID": "x1000c1s7bN",
+      "Type": "Node"
+    },
+    {
+      "Enabled": true,
+      "Flag": "OK",
+      "ID": "x1000c1s7bNn0",
+      "NID": 1,
+      "Role": "Compute",
+      "State": "On",
+      "Type": "Node"
+    },
+```
+for each `N` (in the xname) from 1-9, inclusive.
+
+Check BSS is populated with `ochami bss boot params get | jq`
+```json
+[
+  {
+    "cloud-init": {
+      "meta-data": null,
+      "phone-home": {
+        "fqdn": "",
+        "hostname": "",
+        "instance_id": "",
+        "pub_key_dsa": "",
+        "pub_key_ecdsa": "",
+        "pub_key_rsa": ""
+      },
+      "user-data": null
+    },
+    "initrd": "http://172.16.0.254:8080/openchami/compute-slurm/latest/initramfs-4.18.0-553.27.1.el8_10.x86_64.img",
+    "kernel": "http://172.16.0.254:8080/openchami/compute-slurm/latest/vmlinuz-4.18.0-553.27.1.el8_10.x86_64",
+    "macs": [
+      "ec:e7:a7:05:a1:fc",
+      "ec:e7:a7:05:a2:28",
+      "ec:e7:a7:05:93:84",
+      "ec:e7:a7:02:d9:90",
+      "02:00:00:a8:4f:04",
+      "ec:e7:a7:05:96:74",
+      "02:00:00:97:c4:2e",
+      "ec:e7:a7:05:93:48",
+      "ec:e7:a7:05:9f:50"
+    ],
+    "params": "root=live:http://172.16.0.254:8080/openchami/compute-slurm/latest/rootfs-4.18.0-553.27.1.el8_10.x86_64 ochami_ci_url=http://172.16.0.254:8081/cloud-init/ ochami_ci_url_secure=http://172.16.0.254:8081/cloud-init-secure/ overlayroot=tmpfs overlayroot_cfgdisk=disabled nomodeset ro ip=dhcp apparmor=0 selinux=0 console=ttyS0,115200 ip6=off network-config=disabled rd.shell"
+  }
+]
+```
+We'll have to update these values later when we build a test image. But for now we can see that it is at least working...
+
+Cloud-init should have some data added. You can check with `ochami cloud-init defaults get | jq`. You should see something like:
+```json
+{
+  "base-url": "http://10.0.0.1:27777/cloud-init",
+  "cluster-name": "demo",
+  "nid-length": 3,
+  "public-keys": [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDs70I2ROK/zl9+zVxXTAo+I0vtaNrvViXKQMcqihGvdmCghlcK9P54KBaj3fgh5MGCv+1dxHTWwJmQvw8naw2t+lRpVsdCmGhkXkf6UMgRWJnGxfWWMha7g54Uk16zvbYJi/MKes0pkWLdNsFwpKDKbUi2syvtoEpgpsw4Tc6ayk6S+CxLE+eZVMKbTTaWXoI91KooZAUHTIKSyP61I9/LBD8yWvA4hJirrAhVHezcvn1Jflc7/Rbs75r6jj2yp74a7gsbAxlkj2Ls7o4rMeXJ+Z4lg6qsNwEEan8sSpbNbCjyeOULU0jbigEyh2BxmWR/sQu9TUeHmIgZxOMLxoKX7tKjMudq8ArCIT3W4u1dlWkuhBrzqwQxpTmewIhQot5sVeuc7wO//w4Jw1LteKVc7NXw78bPWhbi/UERNo65/GcBa7vMaAJ4a97xm6ssFRO9UJy/q6X1Y+2+6F/RJ5lxaDxiKygzjZZiRfAWwV+K+Lp0GMysdO6nYwbUAqoHsGs= root@st-head.si.usrc"
+  ],
+  "short-name": "nid"
+}
+```
+
+
+## Booting nodes
+PXE boot the nodes manually to verify the OS installation.
+
+## To cleanup OpenCHAMI installation
+Run the provided playbook:
+```bash
+ansible-playbook -i inventory ochami_cleanup.yaml
+```

--- a/dell/podman-quadlets/bss.yaml
+++ b/dell/podman-quadlets/bss.yaml
@@ -1,0 +1,4 @@
+- name: 'ochami bss'
+  hosts: ochami
+  roles:
+    - { role: bss, tags: ['bss'] }

--- a/dell/podman-quadlets/cloud_init.yaml
+++ b/dell/podman-quadlets/cloud_init.yaml
@@ -1,0 +1,4 @@
+- name: 'ochami cloud init'
+  hosts: ochami
+  roles:
+    - { role: cloud_init, tags: ['cloud_init'] }

--- a/dell/podman-quadlets/configs.yaml
+++ b/dell/podman-quadlets/configs.yaml
@@ -1,0 +1,4 @@
+- name: 'ochami configs'
+  hosts: ochami
+  roles:
+    - { role: configs, tags: ['configs'] }

--- a/dell/podman-quadlets/image.yaml
+++ b/dell/podman-quadlets/image.yaml
@@ -1,0 +1,4 @@
+- name: 'ochami image'
+  hosts: ochami
+  roles:
+    - { role: image, tags: ['image'] }

--- a/dell/podman-quadlets/inventory/01-ochami
+++ b/dell/podman-quadlets/inventory/01-ochami
@@ -1,0 +1,3 @@
+[ochami]
+localhost ansible_connection=local
+#localhost ansible_port=22 ansible_ssh_common_args="-o StrictHostKeyChecking=no"

--- a/dell/podman-quadlets/inventory/group_vars/ochami/cluster.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/cluster.yaml
@@ -1,0 +1,19 @@
+cluster_name: "demo"
+cluster_shortname: "nid"
+cluster_nidlength: 3
+cluster_domain: "openchami.cluster"
+cluster_boot_ip: 172.16.0.254
+cluster_boot_interface: ens259f0
+cluster_env_key: "{{ cluster_name | upper }}_ACCESS_TOKEN"
+
+ochami_base_url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443"
+ochami_smd_url: "{{ ochami_base_url }}/hsm/v2"
+ochami_bss_url: "{{ ochami_base_url }}/boot/v1"
+ochami_cloud_init_url: "{{ ochami_base_url }}/cloud-init"
+
+rhel_tag: 10.0
+
+rhel_repos:
+  - { name: 'RHEL10_Epel', url: 'https://dl.fedoraproject.org/pub/epel/10.0/Everything/x86_64/', gpg: 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10' }
+  - { name: 'RHEL10_BaseOS', url: '', gpg: '' }
+  - { name: 'RHEL10_AppStream', url: '', gpg: '' }

--- a/dell/podman-quadlets/inventory/group_vars/ochami/coredhcp.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/coredhcp.yaml
@@ -1,0 +1,10 @@
+coredhcp_server_id: '{{ cluster_boot_ip }}'
+coredhcp_dns_server: '{{ cluster_boot_ip }}'
+coredhcp_router: '{{ cluster_boot_ip }}'
+coredhcp_netmask: '255.255.255.0'
+coredhcp_dhcp_pool: '172.16.0.200 172.16.0.250'
+coredhcp_tmp_lease_duration: '5m'
+coredhcp_lease_duration: '1h'
+coredhcp_cache_validity: '30s'
+coredhcp_custom_ipxe: 'default'
+coredhcp_tftp_single_port_mode: true

--- a/dell/podman-quadlets/inventory/group_vars/ochami/groups.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/groups.yaml
@@ -1,0 +1,12 @@
+_xnames: |
+  {% for item in nodes %}
+  - {{ item.xname }}
+  {% endfor %}
+
+xnames: '{{ _xnames | from_yaml }}'
+
+group_name: compute
+
+ochami_groups:
+  compute: '{{ xnames }}'
+

--- a/dell/podman-quadlets/inventory/group_vars/ochami/images.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/images.yaml
@@ -1,0 +1,56 @@
+
+base_image_packages:
+# Core init + system
+  - systemd
+  - systemd-udev
+  - kernel
+  - dracut
+  - dracut-live
+  - dracut-network
+  - squashfs-tools
+  - nfs-utils
+
+  # Networking
+  - NetworkManager
+  - nm-connection-editor
+  - iproute
+  - iputils
+  - curl
+
+  # Base tools dracut wants
+  - bash
+  - coreutils
+  - grep
+  - sed
+  - gawk
+  - gzip
+  - findutils
+  - util-linux
+  - kbd
+  - lsof
+  - cryptsetup
+  - lvm2
+  - device-mapper
+
+  # Logging & time
+  - rsyslog
+  - chrony
+
+  # Cloud/init helpers
+  - sudo
+  - wget
+  - cloud-init
+
+base_compute_image_packages:
+  - git
+  - nfs-utils
+  - tcpdump
+  - traceroute
+  - vim
+
+base_image_commands:
+  - "dracut --add 'dmsquash-live livenet network-manager' --install '/usr/lib/systemd/systemd-sysroot-fstab-check' --kver $(basename /lib/modules/*) -N -f --logfile /tmp/dracut.log 2>/dev/null"
+  - "echo DRACUT LOG:; cat /tmp/dracut.log"
+
+base_compute_image_commands:
+  - "useradd -mG wheel -p '$6$VHdSKZNm$O3iFYmRiaFQCemQJjhfrpqqV7DdHBi5YpY6Aq06JSQpABPw.3d8PQ8bNY9NuZSmDv7IL/TsrhRJ6btkgKaonT.' testuser"

--- a/dell/podman-quadlets/inventory/group_vars/ochami/nodes.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/nodes.yaml
@@ -1,0 +1,12 @@
+nodes:
+- name: nid001
+  xname: x1000c1s7b1n0
+  nid: 1
+  group: compute
+  bmc_mac: c2:77:05:e2:03:48
+  bmc_ip: 172.16.0.101
+  interfaces:
+  - mac_addr: ec:e7:a7:05:a1:fc
+    ip_addrs:
+    - name: management
+      ip_addr: 172.16.0.1

--- a/dell/podman-quadlets/inventory/group_vars/ochami/packages.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/packages.yaml
@@ -1,0 +1,15 @@
+ochami_package_dependencies:
+  - buildah
+  - jq
+  - netavark
+  - podman
+  - python3
+  - python3-pip
+  - python3-pyyaml
+  - python3-requests
+
+ochami_pip_packages:
+  - requests
+  - pyyaml
+  - jwt
+  - jmespath

--- a/dell/podman-quadlets/inventory/group_vars/ochami/podman_secrets.yaml
+++ b/dell/podman-quadlets/inventory/group_vars/ochami/podman_secrets.yaml
@@ -1,0 +1,2 @@
+minio_s3_username: admin
+minio_s3_password: admin123

--- a/dell/podman-quadlets/ochami_cleanup.yaml
+++ b/dell/podman-quadlets/ochami_cleanup.yaml
@@ -1,0 +1,4 @@
+- name: 'Cleanup ochami'
+  hosts: ochami
+  roles:
+    - { role: cleanup, tags: ['cleanup'] }

--- a/dell/podman-quadlets/ochami_playbook.yaml
+++ b/dell/podman-quadlets/ochami_playbook.yaml
@@ -1,0 +1,5 @@
+- import_playbook: configs.yaml
+- import_playbook: smd.yaml
+- import_playbook: image.yaml
+- import_playbook: bss.yaml
+- import_playbook: cloud_init.yaml

--- a/dell/podman-quadlets/roles/auth/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/auth/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- name: Generate access token
+  ansible.builtin.shell: sudo bash -lc 'gen_access_token'
+  register: access_token_result
+  changed_when: false
+
+- name: Set ochami_env
+  ansible.builtin.set_fact:
+    ochami_env: "{{ { cluster_env_key: access_token_result.stdout } }}"

--- a/dell/podman-quadlets/roles/bss/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/bss/defaults/main.yaml
@@ -1,0 +1,8 @@
+rhel_base_compute_image_name: rhel-compute
+bss_template: bss.yaml.j2
+openchami_work_dir: /opt/workdir
+bss_dest: '{{ openchami_work_dir }}/boot/bss-{{ group_name }}.yaml'
+file_perm_rw: '0644'
+file_perm_rwx: '0755'
+bss_params_cloud_init: 'ds=nocloud;s=http://{{ cluster_boot_ip }}:8081/cloud-init/'
+bss_params_opts: 'ip=dhcp rd.live.image rd.live.ram rd.neednet=1 rd.driver.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas modprobe.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas libata.force=1:disable,2:disable,3:disable,4:disable rd.luks=0 rd.md=0 rd.dm=0 console=tty0 console=ttyS0,115200 selinux=0 apparmor=0 ip6=off cloud-init=enabled'

--- a/dell/podman-quadlets/roles/bss/meta/main.yaml
+++ b/dell/podman-quadlets/roles/bss/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: auth

--- a/dell/podman-quadlets/roles/bss/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/bss/tasks/main.yaml
@@ -1,0 +1,53 @@
+---
+- name: Configure the bss
+  environment: "{{ ochami_env }}"
+  block:
+    - name: Verify image, kernel and initramfs in S3
+      ansible.builtin.shell: s3cmd ls -Hr s3://boot-images | grep {{ rhel_base_compute_image_name }} | grep {{ rhel_tag }} | awk '{print $4}' | sed 's|s3://||'
+      changed_when: false
+      register: verify_s3_image
+
+    - name: Verify s3 image output
+      ansible.builtin.debug:
+        msg: "{{ verify_s3_image.stdout_lines }}"
+
+    - name: Initialize kernel and initrd
+      ansible.builtin.set_fact:
+        kernel: ""
+        initrd: ""
+
+    - name: Set kernel and initrd variables
+      ansible.builtin.set_fact:
+        kernel: "{{ verify_s3_image.stdout_lines | select('search', 'vmlinuz') | list | first }}"
+        initrd: "{{ verify_s3_image.stdout_lines | select('search', 'initramfs') | list | first }}"
+      when: verify_s3_image.stdout_lines | length > 1
+
+    - name: Fail if kernel or initrd length less than 1
+      ansible.builtin.fail:
+        msg: "Failed to set kernel or initrd. Please verify the compute image created"
+      when: kernel | length < 1 or initrd | length < 1
+
+    - name: Create boot directory
+      ansible.builtin.file:
+        path: '{{ openchami_work_dir }}/boot'
+        state: directory
+        mode: '{{ file_perm_rwx }}'
+
+    - name: Load bss template
+      ansible.builtin.template:
+        src: '{{ bss_template }}'
+        dest: '{{ bss_dest }}'
+        mode: '{{ file_perm_rw }}'
+
+    - name: Set boot configuration
+      ansible.builtin.command: ochami bss boot params set -f yaml -d @{{ openchami_work_dir }}/boot/bss-compute.yaml
+      changed_when: true
+
+    - name: Verify boot params set
+      ansible.builtin.command: ochami bss boot params get -F yaml
+      changed_when: false
+      register: boot_params_output
+
+    - name: Verify boot params output
+      ansible.builtin.debug:
+        msg: "{{ boot_params_output.stdout_lines }}"

--- a/dell/podman-quadlets/roles/bss/templates/bss.yaml.j2
+++ b/dell/podman-quadlets/roles/bss/templates/bss.yaml.j2
@@ -1,0 +1,10 @@
+---
+kernel: 'http://{{ cluster_boot_ip }}:9000/{{ kernel }}'
+initrd: 'http://{{ cluster_boot_ip }}:9000/{{ initrd }}'
+params: 'nomodeset ro root=live:http://{{ cluster_boot_ip }}:9000/boot-images/{{ group_name }}/{{ rhel_base_compute_image_name }}/rhel{{ rhel_tag }}-{{ rhel_base_compute_image_name }}-{{ rhel_tag }} {{ bss_params_opts }} {{ bss_params_cloud_init }}'
+macs:
+{% for item in nodes %}
+{% if item.group == group_name %}
+  - {{ item.interfaces[0].mac_addr }}
+{% endif %}
+{% endfor %}

--- a/dell/podman-quadlets/roles/cleanup/tasks/main.yml
+++ b/dell/podman-quadlets/roles/cleanup/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Load cleanup to root
+  ansible.builtin.template:
+    src: cleanup.sh.j2
+    dest: /root/cleanup.sh
+    mode: 0755
+
+- name: Run cleanup
+  ansible.builtin.shell:
+    bash /root/cleanup.sh
+  changed_when: true
+  register: cleanup
+
+- name: Cleanup output
+  ansible.builtin.debug:
+    msg: "{{ cleanup.stdout_lines }}"

--- a/dell/podman-quadlets/roles/cleanup/templates/cleanup.sh.j2
+++ b/dell/podman-quadlets/roles/cleanup/templates/cleanup.sh.j2
@@ -1,0 +1,81 @@
+echo "Removing openchami packages"
+dnf remove ochami -y
+dnf remove openchami -y
+systemctl stop openchami.target
+rm -rf /etc/containers/systemd/registry.container
+rm -rf /etc/containers/systemd/minio.container
+sudo systemctl daemon-reload
+
+echo "Removing openchami containers, volume and secrets"
+# Containers
+containers=(
+  minio-server registry step-ca postgres hydra
+  opaal-idp smd bss opaal cloud-init-server
+  haproxy coresmd
+)
+
+for container in "${containers[@]}"; do
+  podman rm -f "$container" 2>/dev/null && echo "Removed container: $container" || echo "Container not found: $container"
+done
+
+# Volumes
+volumes=(
+  haproxy-certs acme-certs postgres-data
+  step-ca-db step-root-ca step-ca-home
+)
+
+for volume in "${volumes[@]}"; do
+  podman volume rm -f "$volume" 2>/dev/null && echo "Removed volume: $volume" || echo "Volume not found: $volume"
+done
+
+# Secrets
+secrets=(
+  hydra_postgres_password hydra_dsn hydra_system_secret
+  smd_postgres_password postgres_password
+  postgres_multiple_databases bss_postgres_password
+)
+
+for secret in "${secrets[@]}"; do
+  podman secret rm "$secret" 2>/dev/null && echo "Removed secret: $secret" || echo "Secret not found: $secret"
+done
+
+
+echo "Cleanup firewall config"
+# lists of ports and interfaces used
+TCP_PORTS=(9000 9001 5000 5432 27778 27779 8081 8443)
+UDP_PORTS=(69 67 68)
+PODMAN_INTERFACES=(podman0 podman1 podman2 podman3 podman4)
+
+# Remove TCP ports
+for port in "${TCP_PORTS[@]}"; do
+  sudo firewall-cmd --permanent --remove-port=${port}/tcp
+done
+
+# Remove UDP ports
+for port in "${UDP_PORTS[@]}"; do
+  sudo firewall-cmd --permanent --remove-port=${port}/udp
+done
+
+# Remove podman interfaces from trusted zone
+for iface in "${PODMAN_INTERFACES[@]}"; do
+  sudo firewall-cmd --permanent --zone=trusted --remove-interface=${iface}
+done
+
+# Reload firewalld
+sudo firewall-cmd --reload
+
+echo "Removing s3cmd and regctl config"
+s3cmd del s3://efi
+s3cmd del s3://boot-images
+dnf remove s3cmd -y
+rm -rf ~/.regctl/config.json
+rm -rf /usr/local/bin/regctl
+
+echo "Removing openchami config directory"
+rm -rf /data/oci
+rm -rf /data/s3
+rm -rf /opt/workdir
+rm -rf /etc/openchami
+rm -rf /etc/ochami
+
+echo "Cleanup complete."

--- a/dell/podman-quadlets/roles/cloud_init/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/cloud_init/defaults/main.yaml
@@ -1,0 +1,8 @@
+ssh_key_path: /root/.ssh/id_ed25519
+file_perm_rw: '0644'
+file_perm_rwx: '0755'
+ci_defaults_template: ci-defaults.yaml.j2
+openchami_work_dir: /opt/workdir
+ci_defaults_dest: '{{ openchami_work_dir }}/cloud-init/ci-defaults.yaml'
+ci_group_compute_template: ci-group-compute.yaml.j2
+ci_group_compute_dest: '{{ openchami_work_dir }}/cloud-init/ci-group-compute.yaml'

--- a/dell/podman-quadlets/roles/cloud_init/meta/main.yaml
+++ b/dell/podman-quadlets/roles/cloud_init/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: auth

--- a/dell/podman-quadlets/roles/cloud_init/tasks/ci_defaults.yaml
+++ b/dell/podman-quadlets/roles/cloud_init/tasks/ci_defaults.yaml
@@ -1,0 +1,32 @@
+- name: Verify the ssh key exist
+  ansible.builtin.stat:
+    path: "{{ ssh_key_path }}.pub"
+  register: ssh_path_stat
+
+- name: Create ssh key
+  ansible.builtin.shell: bash -c "yes | ssh-keygen -t ed25519 -f {{ ssh_key_path }} -N ''"
+  changed_when: false
+  when: not ssh_path_stat.stat.exists
+
+- name: Read the ssh key
+  ansible.builtin.command: cat {{ ssh_key_path }}.pub
+  register: read_ssh_key
+
+- name: Load ci defaults template
+  ansible.builtin.template:
+    src: '{{ ci_defaults_template }}'
+    dest: '{{ ci_defaults_dest }}'
+    mode: '{{ file_perm_rw }}'
+
+- name: Set ci defaults configuration
+  ansible.builtin.command: ochami cloud-init defaults set -f yaml -d @{{ ci_defaults_dest }}
+  changed_when: true
+
+- name: Verify ci defaults configuration
+  ansible.builtin.command: ochami cloud-init defaults get -F json-pretty
+  changed_when: false
+  register: ci_defaults_output
+
+- name: Verify ci defaults output
+  ansible.builtin.debug:
+    msg: "{{ ci_defaults_output.stdout_lines }}"

--- a/dell/podman-quadlets/roles/cloud_init/tasks/ci_group_compute.yaml
+++ b/dell/podman-quadlets/roles/cloud_init/tasks/ci_group_compute.yaml
@@ -1,0 +1,18 @@
+- name: Load ci group {{ group_name }} template
+  ansible.builtin.template:
+    src: '{{ ci_group_compute_template }}'
+    dest: '{{ ci_group_compute_dest }}'
+    mode: '{{ file_perm_rw }}'
+
+- name: Set ci group {{ group_name }} configuration
+  ansible.builtin.command: ochami cloud-init group set -f yaml -d @{{ ci_group_compute_dest }}
+  changed_when: true
+
+- name: Verify ci group compute configuration
+  ansible.builtin.command: ochami cloud-init group get config {{ group_name }}
+  changed_when: false
+  register: ci_group_compute_output
+
+- name: Verify ci group {{ group_name }} output
+  ansible.builtin.debug:
+    msg: "{{ ci_group_compute_output.stdout_lines }}"

--- a/dell/podman-quadlets/roles/cloud_init/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/cloud_init/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Configure the cloud-init
+  environment: "{{ ochami_env }}"
+  block:
+    - name: Create cloud-init directory
+      ansible.builtin.file:
+        path: '{{ openchami_work_dir }}/cloud-init'
+        state: directory
+        mode: '{{ file_perm_rwx }}'
+
+    - name: Cloud init defaults configuration
+      ansible.builtin.import_tasks: ci_defaults.yaml
+
+    - name: Cloud init group compute configuration
+      ansible.builtin.import_tasks: ci_group_compute.yaml

--- a/dell/podman-quadlets/roles/cloud_init/templates/ci-defaults.yaml.j2
+++ b/dell/podman-quadlets/roles/cloud_init/templates/ci-defaults.yaml.j2
@@ -1,0 +1,7 @@
+---
+base-url: "http://{{ cluster_boot_ip }}:8081/cloud-init"
+cluster-name: "{{ cluster_name }}"
+nid-length: 3
+public-keys:
+- "{{ read_ssh_key.stdout }}"
+short-name: "{{ cluster_shortname }}"

--- a/dell/podman-quadlets/roles/cloud_init/templates/ci-group-compute.yaml.j2
+++ b/dell/podman-quadlets/roles/cloud_init/templates/ci-group-compute.yaml.j2
@@ -1,0 +1,16 @@
+- name: {{ group_name }}
+  description: "{{ group_name }} config"
+  file:
+    encoding: plain
+    content: |
+      ## template: jinja
+      #cloud-config
+      merge_how:
+      - name: list
+        settings: [append]
+      - name: dict
+        settings: [no_replace, recurse_list]
+      users:
+        - name: root
+          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+      disable_root: false

--- a/dell/podman-quadlets/roles/configs/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/configs/defaults/main.yaml
@@ -1,0 +1,39 @@
+ochami_cli_log_level: warning
+ochami_cli_log_format: rfc3339
+ochami_dir: /etc/ochami
+openchami_dir: /etc/openchami
+openchami_config_dir: '{{ openchami_dir }}/configs'
+file_perm_rw: 0644
+file_perm_rwx: 0755
+openchami_work_dir: /opt/workdir
+s3_work_dir: /opt/workdir
+data_oci_dir: /data/oci
+data_s3_dir: /data/s3
+openchami_api_url: "https://api.github.com/repos/openchami/release/releases/latest"
+ochami_client_api_url: "https://api.github.com/repos/OpenCHAMI/ochami/releases/latest"
+tcp_ports:
+  - 9000
+  - 9001
+  - 5000
+  - 5432
+  - 27778
+  - 27779
+  - 8081
+  - 8443
+udp_ports:
+  - 69
+  - 67
+  - 68
+podman_interfaces:
+  - podman0
+  - podman1
+  - podman2
+  - podman3
+  - podman4
+wait_time: 10
+max_delay: 10
+max_retries: 10
+regctl_url: https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64
+regctl_dest: /usr/local/bin/regctl
+epel10_url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+epel10_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10

--- a/dell/podman-quadlets/roles/configs/handlers/main.yaml
+++ b/dell/podman-quadlets/roles/configs/handlers/main.yaml
@@ -1,0 +1,3 @@
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/dell/podman-quadlets/roles/configs/tasks/configs.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/configs.yaml
@@ -1,0 +1,14 @@
+- name: Create ochami directory
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: directory
+    mode: '{{ file_perm_rwx }}'
+    owner: root
+    group: root
+  with_items:
+    - '{{ data_oci_dir }}'
+    - '{{ data_s3_dir }}'
+    - '{{ openchami_work_dir }}'
+    - '{{ openchami_config_dir }}'
+    - '{{ ochami_dir }}'
+    - '{{ s3_work_dir }}'

--- a/dell/podman-quadlets/roles/configs/tasks/firewall.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/firewall.yaml
@@ -1,0 +1,31 @@
+- name: Ensure firewalld is running
+  ansible.builtin.service:
+    name: firewalld
+    state: started
+    enabled: true
+
+- name: Open TCP ports
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
+    permanent: yes
+    state: enabled
+  loop: "{{ tcp_ports }}"
+
+- name: Open UDP ports
+  ansible.posix.firewalld:
+    port: "{{ item }}/udp"
+    permanent: yes
+    state: enabled
+  loop: "{{ udp_ports }}"
+
+- name: Add Podman interfaces to trusted zone
+  ansible.posix.firewalld:
+    interface: "{{ item }}"
+    zone: trusted
+    permanent: true
+    state: enabled
+  loop: "{{ podman_interfaces }}"
+
+- name: Reload firewalld to apply changes
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: true

--- a/dell/podman-quadlets/roles/configs/tasks/hosts.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/hosts.yaml
@@ -1,0 +1,5 @@
+- name: Add OpenCHAMI host to hosts file
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ cluster_boot_ip }} {{ cluster_name }}.{{ cluster_domain }}"
+    create: true

--- a/dell/podman-quadlets/roles/configs/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: Import packages task
+  ansible.builtin.import_tasks: packages.yaml
+
+- name: Import configs task
+  ansible.builtin.import_tasks: configs.yaml
+
+- name: Import hosts task
+  ansible.builtin.import_tasks: hosts.yaml
+
+- name: Import minio task
+  ansible.builtin.import_tasks: minio.yaml
+
+- name: Import registry task
+  ansible.builtin.import_tasks: registry.yaml
+
+- name: Import ochami task
+  ansible.builtin.import_tasks: ochami.yaml
+
+- name: Import firewall task
+  ansible.builtin.import_tasks: firewall.yaml
+
+- name: Import verify task
+  ansible.builtin.import_tasks: verify.yaml
+
+- name: Import regctl tasks
+  ansible.builtin.import_tasks: regctl.yaml
+
+- name: Import s3 bucket tasks
+  ansible.builtin.import_tasks: s3_bucket.yaml
+
+- name: Import policy update tasks
+  ansible.builtin.import_tasks: policy_update.yaml

--- a/dell/podman-quadlets/roles/configs/tasks/minio.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/minio.yaml
@@ -1,0 +1,15 @@
+- name: Drop minio Quadlet files
+  ansible.builtin.template:
+    src: minio/minio.service.j2
+    dest: '/etc/containers/systemd/minio.container'
+    owner: root
+    group: root
+    mode: '{{ file_perm_rw }}'
+  notify: Reload systemd
+
+- name: Start minio service
+  ansible.builtin.service:
+    name: minio.service
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/dell/podman-quadlets/roles/configs/tasks/ochami.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/ochami.yaml
@@ -1,0 +1,71 @@
+- name: Get latest openchami response
+  ansible.builtin.uri:
+    url: "{{ openchami_api_url }}"
+    return_content: true
+  register: openchami_release_response
+
+- name: Extract openchami RPM download URL
+  ansible.builtin.set_fact:
+    openchami_rpm_url: "{{ openchami_release_response.content | from_json | json_query('assets[?ends_with(name, `.rpm`)].browser_download_url') | first }}"
+    openchami_rpm_name: "{{ openchami_release_response.content | from_json | json_query('assets[?ends_with(name, `.rpm`)].name') | first }}"
+
+- name: Download the openchami RPM file
+  ansible.builtin.get_url:
+    url: "{{ openchami_rpm_url }}"
+    dest: "{{ openchami_work_dir }}/{{ openchami_rpm_name }}"
+    mode: "{{ file_perm_rwx }}"
+  register: download_openchami
+  until: download_openchami is not failed
+  retries: "{{ max_retries }}"
+  delay: "{{ max_delay }}"
+
+- name: Install the openchami
+  ansible.builtin.dnf:
+    name: "{{ openchami_work_dir }}/{{ openchami_rpm_name }}"
+    state: present
+    disable_gpg_check: true
+
+- name: Get ochami client respone
+  ansible.builtin.uri:
+    url: "{{ ochami_client_api_url }}"
+    return_content: true
+  register: ochami_client_release_response
+
+- name: Extract ochami RPM download URL
+  ansible.builtin.set_fact:
+    ochami_client_rpm_url: "{{ ochami_client_release_response.content | from_json | json_query('assets[?ends_with(name, `amd64.rpm`)].browser_download_url') | first }}"
+    ochami_client_rpm_name: "{{ ochami_client_release_response.content | from_json | json_query('assets[?ends_with(name, `amd64.rpm`)].name') | first }}"
+
+- name: Download the ochami client RPM file
+  ansible.builtin.get_url:
+    url: "{{ ochami_client_rpm_url }}"
+    dest: "{{ openchami_work_dir }}/{{ ochami_client_rpm_name }}"
+    mode: "{{ file_perm_rwx }}"
+  register: download_ochami
+  until: download_ochami is not failed
+  retries: "{{ max_retries }}"
+  delay: "{{ max_delay }}"
+
+- name: Install ochami CLI
+  ansible.builtin.dnf:
+    name: "{{ openchami_work_dir }}/{{ ochami_client_rpm_name }}"
+    state: present
+    disable_gpg_check: true
+
+- name: Configure ochami CLI
+  ansible.builtin.template:
+    src: ochami/config.yaml.j2
+    dest: '{{ ochami_dir }}/config.yaml'
+    mode: '{{ file_perm_rw }}'
+
+- name: Drop coredhcp config file
+  ansible.builtin.template:
+    src: coredhcp/coredhcp.yaml.j2
+    dest: '{{ openchami_config_dir }}/coredhcp.yaml'
+    owner: root
+    group: root
+    mode: '{{ file_perm_rw }}'
+
+- name: Configure cluster FQDN for certificates
+  ansible.builtin.command: sudo openchami-certificate-update update {{ cluster_name }}.{{ cluster_domain }}
+  changed_when: true

--- a/dell/podman-quadlets/roles/configs/tasks/packages.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/packages.yaml
@@ -1,0 +1,10 @@
+- name: Install ochami dependent packages
+  ansible.builtin.dnf:
+    name: '{{ ochami_package_dependencies }}'
+    state: present
+
+- name: Install pip packages
+  ansible.builtin.pip:
+    name: '{{ ochami_pip_packages }}'
+    state: present
+    executable: pip3

--- a/dell/podman-quadlets/roles/configs/tasks/policy_update.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/policy_update.yaml
@@ -1,0 +1,25 @@
+- name: Load boot policy file
+  ansible.builtin.template:
+    src: s3/s3-public-read-boot.json.j2
+    dest: '{{ s3_work_dir }}/s3-public-read-boot.json'
+    mode: '{{ file_perm_rw }}'
+
+- name: Load efi policy file
+  ansible.builtin.template:
+    src: s3/s3-public-read-efi.json.j2
+    dest: '{{ s3_work_dir }}/s3-public-read-efi.json'
+    mode: '{{ file_perm_rw }}'
+
+- name: Update the boot policy
+  ansible.builtin.command: >
+    s3cmd setpolicy {{ s3_work_dir }}/s3-public-read-boot.json s3://boot-images \
+    --host={{ cluster_boot_ip }}:9000 \
+    --host-bucket={{ cluster_boot_ip }}:9000
+  changed_when: true
+
+- name: Update the efi policy
+  ansible.builtin.command: >
+    s3cmd setpolicy {{ s3_work_dir }}/s3-public-read-efi.json s3://efi \
+    --host={{ cluster_boot_ip }}:9000 \
+    --host-bucket={{ cluster_boot_ip }}:9000
+  changed_when: true

--- a/dell/podman-quadlets/roles/configs/tasks/regctl.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/regctl.yaml
@@ -1,0 +1,20 @@
+- name: Install regctl binary
+  ansible.builtin.get_url:
+    url: '{{ regctl_url }}'
+    dest: '{{ regctl_dest }}'
+    mode: '{{ file_perm_rwx }}'
+
+- name: Configure regctl
+  ansible.builtin.shell: |
+    /usr/local/bin/regctl registry set --tls disabled {{ cluster_name }}.{{ cluster_domain }}:5000
+  changed_when: true
+
+- name: Verify regctl configs
+  ansible.builtin.shell: |
+    cat ~/.regctl/config.json 
+  changed_when: false
+  register: regctl_config
+
+- name: Verify regctl config output
+  ansible.builtin.debug:
+    msg: "{{ regctl_config.stdout_lines }}"

--- a/dell/podman-quadlets/roles/configs/tasks/registry.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/registry.yaml
@@ -1,0 +1,15 @@
+- name: Drop registry Quadlet files
+  ansible.builtin.template:
+    src: registry/registry.service.j2
+    dest: '/etc/containers/systemd/registry.container'
+    owner: root
+    group: root
+    mode: '{{ file_perm_rw }}'
+  notify: Reload systemd
+
+- name: Start registry service
+  ansible.builtin.service:
+    name: registry.service
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/dell/podman-quadlets/roles/configs/tasks/s3_bucket.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/s3_bucket.yaml
@@ -1,0 +1,57 @@
+- name: Import EPEL GPG key
+  ansible.builtin.rpm_key:
+    key: '{{ epel10_gpg_key }}'
+    state: present
+
+- name: Install EPEL release RPM
+  ansible.builtin.dnf:
+    name: '{{ epel10_url }}'
+    state: present
+
+- name: Install s3cmd
+  ansible.builtin.dnf:
+    name: s3cmd
+    state: present
+
+- name: Create s3cfg
+  ansible.builtin.template:
+    src: s3/s3cfg.j2
+    dest: '/root/.s3cfg'
+    mode: '{{ file_perm_rw }}'
+
+- name: Verify s3 bucket
+  ansible.builtin.command: s3cmd ls
+  changed_when: false
+  failed_when: false
+  register: s3_bucket_output
+
+- name: Create S3 bucket 'efi'
+  ansible.builtin.command: s3cmd mb s3://efi
+  register: efi_bucket
+  changed_when: "'Bucket' in efi_bucket.stdout"
+  when: '"s3://efi" not in s3_bucket_output.stdout' 
+
+- name: Set ACL to public for 'efi'
+  command: s3cmd setacl s3://efi --acl-public
+  changed_when: true
+  when: '"s3://efi" not in s3_bucket_output.stdout' 
+
+- name: Create S3 bucket 'boot-images'
+  command: s3cmd mb s3://boot-images
+  register: boot_images_bucket
+  changed_when: "'Bucket' in boot_images_bucket.stdout"
+  when: '"s3://boot-images" not in s3_bucket_output.stdout' 
+
+- name: Set ACL to public for 'boot-images'
+  command: s3cmd setacl s3://boot-images --acl-public
+  changed_when: true
+  when: '"s3://boot-images" not in s3_bucket_output.stdout' 
+
+- name: Verify s3 bucket
+  ansible.builtin.command: s3cmd ls
+  changed_when: false
+  register: s3_bucket_output
+
+- name: Verify s3 bucket output
+  ansible.builtin.debug:
+    msg: "{{ s3_bucket_output.stdout_lines }}"

--- a/dell/podman-quadlets/roles/configs/tasks/verify.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/verify.yaml
@@ -1,0 +1,31 @@
+- name: Verify ochami installation
+  block:
+    - name: Start the openchami service (This task will take some time)
+      ansible.builtin.systemd:
+        name: openchami.target
+        state: restarted
+        enabled: true
+        daemon_reload: true
+
+    - name: Configure ochami
+      ansible.builtin.command: sudo ochami config cluster set --system --default {{ cluster_name }} cluster.uri https://{{ cluster_name }}.{{ cluster_domain }}:8443
+      changed_when: true
+
+    - name: Verify openchami service
+      ansible.builtin.import_tasks: verify_ochami.yaml
+      vars:
+        max_retries: 1
+  rescue:
+    - name: Restart openchami in case of error
+      ansible.builtin.systemd:
+        name: openchami.target
+        state: restarted
+        enabled: true
+        daemon_reload: true
+    
+    - name: Configure ochami
+      ansible.builtin.command: sudo ochami config cluster set --system --default {{ cluster_name }} cluster.uri https://{{ cluster_name }}.{{ cluster_domain }}:8443
+      changed_when: true
+
+    - name: Verify openchami service
+      ansible.builtin.import_tasks: verify_ochami.yaml

--- a/dell/podman-quadlets/roles/configs/tasks/verify_ochami.yaml
+++ b/dell/podman-quadlets/roles/configs/tasks/verify_ochami.yaml
@@ -1,0 +1,51 @@
+- name: Generate access token
+  ansible.builtin.shell: sudo bash -lc 'gen_access_token'
+  register: access_token_result
+  changed_when: false
+
+- name: Set ochami_env
+  ansible.builtin.set_fact:
+    ochami_env: "{{ { cluster_env_key: access_token_result.stdout } }}"
+
+- name: Verify ochami installation
+  environment: "{{ ochami_env }}"
+  block:
+    - name: wait for {{ wait_time }} seconds
+      ansible.builtin.wait_for:
+        timeout: "{{ wait_time }}"
+
+    - name: Verify ochami dependencies
+      ansible.builtin.shell:
+        systemctl list-dependencies openchami.target
+      register: openchami_dependencies
+      changed_when: false
+
+    - name: Openchami dependencies output
+      ansible.builtin.debug:
+        msg: "{{ openchami_dependencies.stdout_lines }}"
+
+    - name: Verify ochami bss status
+      ansible.builtin.shell:
+        ochami bss service status
+      register: openchami_bss_status
+      until: openchami_bss_status.rc == 0
+      retries: "{{ max_retries }}"
+      delay: "{{ max_delay }}"
+      changed_when: false
+
+    - name: Openchami bss status output
+      ansible.builtin.debug:
+        msg: "{{ openchami_bss_status.stdout_lines }}"
+
+    - name: Verify ochami smd status
+      ansible.builtin.shell:
+        ochami smd service status
+      register: openchami_smd_status
+      until: openchami_smd_status.rc == 0
+      retries: "{{ max_retries }}"
+      delay: "{{ max_delay }}"
+      changed_when: false
+
+    - name: Openchami smd status output
+      ansible.builtin.debug:
+        msg: "{{ openchami_smd_status.stdout_lines }}"

--- a/dell/podman-quadlets/roles/configs/templates/coredhcp/coredhcp.yaml.j2
+++ b/dell/podman-quadlets/roles/configs/templates/coredhcp/coredhcp.yaml.j2
@@ -1,0 +1,10 @@
+server4:
+  listen:
+    - "%{{ cluster_boot_interface }}"
+  plugins:
+    - server_id: {{ coredhcp_server_id }}
+    - dns: {{ coredhcp_dns_server }}
+    - router: {{ coredhcp_router }}
+    - netmask: {{ coredhcp_netmask }}
+    - coresmd: https://{{ cluster_name }}.{{ cluster_domain }}:8443 http://{{ cluster_boot_ip }}:8081 /root_ca/root_ca.crt {{ coredhcp_cache_validity }} {{ coredhcp_lease_duration }} {{ coredhcp_tftp_single_port_mode | lower }}
+    - bootloop: /tmp/coredhcp.db {{ coredhcp_custom_ipxe }} {{ coredhcp_tmp_lease_duration }} {{ coredhcp_dhcp_pool }}

--- a/dell/podman-quadlets/roles/configs/templates/minio/minio.service.j2
+++ b/dell/podman-quadlets/roles/configs/templates/minio/minio.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=Minio S3
+After=local-fs.target network-online.target
+Wants=local-fs.target network-online.target
+
+[Container]
+ContainerName=minio-server
+Image=docker.io/minio/minio:latest
+# Volumes
+Volume={{ data_s3_dir }}:/data:Z
+
+# Ports
+PublishPort=9000:9000
+PublishPort=9001:9001
+
+# Environemnt Variables
+Environment=MINIO_ROOT_USER={{ minio_s3_username }}
+Environment=MINIO_ROOT_PASSWORD={{ minio_s3_password }}
+
+# Command to run in container
+Exec=server /data --console-address :9001
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/dell/podman-quadlets/roles/configs/templates/ochami/config.yaml.j2
+++ b/dell/podman-quadlets/roles/configs/templates/ochami/config.yaml.j2
@@ -1,0 +1,8 @@
+clusters:
+  - cluster:
+      uri: {{ ochami_base_url }}
+    name: {{ cluster_name }}
+default-cluster: {{ cluster_name }}
+log:
+  format: {{ ochami_cli_log_format }}
+  level: {{ ochami_cli_log_level }}

--- a/dell/podman-quadlets/roles/configs/templates/registry/registry.service.j2
+++ b/dell/podman-quadlets/roles/configs/templates/registry/registry.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Image OCI Registry
+After=network-online.target
+Requires=network-online.target
+
+[Container]
+ContainerName=registry
+HostName=registry
+Image=docker.io/library/registry:latest
+Volume={{ data_oci_dir }}:/var/lib/registry:Z
+PublishPort=5000:5000
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/dell/podman-quadlets/roles/configs/templates/s3/s3-public-read-boot.json.j2
+++ b/dell/podman-quadlets/roles/configs/templates/s3/s3-public-read-boot.json.j2
@@ -1,0 +1,11 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Principal":"*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::boot-images/*"]
+    }
+  ]
+}

--- a/dell/podman-quadlets/roles/configs/templates/s3/s3-public-read-efi.json.j2
+++ b/dell/podman-quadlets/roles/configs/templates/s3/s3-public-read-efi.json.j2
@@ -1,0 +1,11 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Principal":"*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::efi/*"]
+    }
+  ]
+}

--- a/dell/podman-quadlets/roles/configs/templates/s3/s3cfg.j2
+++ b/dell/podman-quadlets/roles/configs/templates/s3/s3cfg.j2
@@ -1,0 +1,12 @@
+# Setup endpoint
+host_base = {{ cluster_name }}.{{ cluster_domain }}:9000
+host_bucket = {{ cluster_name }}.{{ cluster_domain }}:9000
+bucket_location = us-east-1
+use_https = False
+
+# Setup access keys
+access_key = {{ minio_s3_username }}
+secret_key = {{ minio_s3_password }}
+
+# Enable S3 v4 signature APIs
+signature_v2 = False

--- a/dell/podman-quadlets/roles/image/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/image/defaults/main.yaml
@@ -1,0 +1,13 @@
+openchami_work_dir: /opt/workdir
+file_perm_rwx: 0755
+file_perm_rw: 0644
+rhel_base_image_name: rhel-base
+rhel_base_image: '{{ cluster_name }}/{{ rhel_base_image_name }}'
+rhel_base_image_template: images/rhel-base.yaml.j2
+rhel_base_compute_image_name: rhel-compute
+rhel_base_compute_image: '{{ cluster_name }}/{{ rhel_base_compute_image_name }}'
+rhel_base_compute_image_template: images/rhel-base-compute.yaml.j2
+image_build_fail_msg: "Error encountered while building image. This can be due to invalid url, packages or network issues."
+rhel_base_compute_mounts: "-v {{ openchami_work_dir }}/images/{{ rhel_base_compute_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z"
+rhel_base_mounts: "-v {{ openchami_work_dir }}/images/{{ rhel_base_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z"
+image_build_name: "ghcr.io/openchami/image-build:latest"

--- a/dell/podman-quadlets/roles/image/tasks/base_compute_image.yaml
+++ b/dell/podman-quadlets/roles/image/tasks/base_compute_image.yaml
@@ -1,0 +1,37 @@
+- name: Configure the {{ rhel_base_compute_image_name }} osimage
+  ansible.builtin.template:
+    src: "{{ rhel_base_compute_image_template }}"
+    dest: "{{ openchami_work_dir }}/images/{{ rhel_base_compute_image_name }}-{{ rhel_tag }}.yaml"
+    mode: '{{ file_perm_rw }}'
+
+- name: Build {{ rhel_base_compute_image_name }} osimage
+  block:
+    - name: Build {{ rhel_base_compute_image_name }} osimage (This task will take some time)
+      ansible.builtin.command:  
+        cmd: >
+          podman run --rm
+          --device /dev/fuse
+          --network host -e S3_ACCESS={{ minio_s3_username }} -e S3_SECRET={{ minio_s3_password }}
+          {{ rhel_base_compute_mounts }}
+          {{ image_build_name }}
+          image-build --config config.yaml --log-level DEBUG
+      changed_when: true
+      register: build_base_compute_osimage
+  rescue:
+    - name: Failed to {{ rhel_base_compute_image_name }} osimage
+      ansible.builtin.debug:
+        msg: "{{ image_build_fail_msg }}. Error: {{ build_base_compute_osimage.stderr_lines }}"
+
+- name: Verify the {{ rhel_base_compute_image_name }} created
+  ansible.builtin.command: regctl repo ls {{ cluster_name }}.{{ cluster_domain }}:5000
+  changed_when: false
+  register: verify_base_compute_osimage
+
+- name: Fail if {{ rhel_base_compute_image_name }} not created
+  ansible.builtin.fail:
+    msg: "Failed to build {{ rhel_base_compute_image_name }} osimage {{ rhel_base_compute_image }}"
+  when: rhel_base_compute_image not in verify_base_compute_osimage.stdout_lines
+
+- name: Verify {{ rhel_base_compute_image_name }} osimage output
+  ansible.builtin.debug:
+    msg: "{{ verify_base_compute_osimage.stdout_lines }}"

--- a/dell/podman-quadlets/roles/image/tasks/base_image.yaml
+++ b/dell/podman-quadlets/roles/image/tasks/base_image.yaml
@@ -1,0 +1,43 @@
+- name: Create ochami images directory
+  ansible.builtin.file:
+    path: '{{ openchami_work_dir }}/images'
+    state: directory
+    mode: '{{ file_perm_rwx }}'
+
+- name: Configure the base osimage
+  ansible.builtin.template:
+    src: "{{ rhel_base_image_template }}"
+    dest: "{{ openchami_work_dir }}/images/{{ rhel_base_image_name }}-{{ rhel_tag }}.yaml"
+    mode: '{{ file_perm_rw }}'
+
+- name: Build base osimage
+  block:
+    - name: Build base osimage (This task will take some time)
+      ansible.builtin.command:  
+        cmd: >
+          podman run --rm
+          --device /dev/fuse
+          --network host
+          {{ rhel_base_mounts }}
+          {{ image_build_name }}
+          image-build --config config.yaml --log-level DEBUG
+      changed_when: true
+      register: build_base_osimage
+  rescue:
+    - name: Failed to build base osimage
+      ansible.builtin.debug:
+        msg: "{{ image_build_fail_msg }}. Error: {{ build_base_osimage.stderr_lines }}"
+
+- name: Verify the base osimage created
+  ansible.builtin.command: regctl repo ls {{ cluster_name }}.{{ cluster_domain }}:5000
+  changed_when: false
+  register: verify_base_osimage
+
+- name: Fail if base osimage not created
+  ansible.builtin.fail:
+    msg: "Failed to build base osimage {{ rhel_base_image }}"
+  when: rhel_base_image not in verify_base_osimage.stdout_lines
+
+- name: Verify base osimage output
+  ansible.builtin.debug:
+    msg: "{{ verify_base_osimage.stdout_lines }}"

--- a/dell/podman-quadlets/roles/image/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/image/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Import base image tasks
+  ansible.builtin.import_tasks: base_image.yaml
+  tags: base_image
+
+- name: Import base compute image tasks
+  ansible.builtin.import_tasks: base_compute_image.yaml
+  tags: compute_image

--- a/dell/podman-quadlets/roles/image/templates/images/rhel-base-compute.yaml.j2
+++ b/dell/podman-quadlets/roles/image/templates/images/rhel-base-compute.yaml.j2
@@ -1,0 +1,35 @@
+options:
+  layer_type: base
+  name: '{{ rhel_base_compute_image_name }}'
+  publish_tags: '{{ rhel_tag }}'
+  pkg_manager: dnf
+  parent: '{{ cluster_name }}.{{ cluster_domain }}:5000/{{ rhel_base_image }}:{{ rhel_tag }}'
+  registry_opts_pull:
+    - '--tls-verify=false'
+  publish_s3: 'http://{{ cluster_name }}.{{ cluster_domain }}:9000'
+  s3_prefix: '{{ group_name }}/{{ rhel_base_compute_image_name }}/'
+  s3_bucket: 'boot-images'
+  publish_registry: '{{ cluster_name }}.{{ cluster_domain }}:5000/{{ cluster_name }}'
+  registry_opts_push:
+    - '--tls-verify=false'
+
+repos:
+{% for repo in rhel_repos %}
+{% if repo.url | length > 1 %}
+  - alias: '{{ repo.name }}'
+    url: '{{ repo.url }}'
+{% endif %}
+{% if repo.gpg | length > 1 %}
+    gpg: '{{ repo.gpg }}'
+{% endif %}
+{% endfor %}
+
+packages:
+{% for pkg in base_compute_image_packages %}
+  - {{ pkg }}
+{% endfor %}
+
+cmds:
+{% for cmd in base_compute_image_commands %}
+  - cmd: "{{ cmd }}"
+{% endfor %}

--- a/dell/podman-quadlets/roles/image/templates/images/rhel-base.yaml.j2
+++ b/dell/podman-quadlets/roles/image/templates/images/rhel-base.yaml.j2
@@ -1,0 +1,33 @@
+options:
+  layer_type: 'base'
+  name: '{{ rhel_base_image_name }}'
+  publish_tags: '{{ rhel_tag }}'
+  pkg_manager: 'dnf'
+  parent: 'scratch'
+  publish_registry: '{{ cluster_name }}.{{ cluster_domain }}:5000/{{ cluster_name }}'
+  registry_opts_push:
+    - '--tls-verify=false'
+
+repos:
+{% for repo in rhel_repos %}
+{% if repo.url | length > 1 %}
+  - alias: '{{ repo.name }}'
+    url: '{{ repo.url }}'
+{% endif %}
+{% if repo.gpg | length > 1 %}
+    gpg: '{{ repo.gpg }}'
+{% endif %}
+{% endfor %}
+
+package_groups:
+  - 'Minimal Install'
+  - 'Development Tools'
+packages:
+{% for pkg in base_image_packages %}
+  - {{ pkg }}
+{% endfor %}
+
+cmds:
+{% for cmd in base_image_commands %}
+  - cmd: "{{ cmd }}"
+{% endfor %}

--- a/dell/podman-quadlets/roles/smd/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/smd/defaults/main.yaml
@@ -1,0 +1,3 @@
+openchami_work_dir: /opt/workdir
+file_perm_rw: 0644
+file_perm_rwx: 0755

--- a/dell/podman-quadlets/roles/smd/meta/main.yaml
+++ b/dell/podman-quadlets/roles/smd/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: auth

--- a/dell/podman-quadlets/roles/smd/tasks/main.yaml
+++ b/dell/podman-quadlets/roles/smd/tasks/main.yaml
@@ -1,0 +1,72 @@
+
+- name: Update smd
+  environment: "{{ ochami_env }}"
+  block:
+    - name: Create ochami nodes directory
+      ansible.builtin.file:
+        path: '{{ openchami_work_dir }}/nodes'
+        state: directory
+        mode: '{{ file_perm_rwx }}'
+
+    - name: Drop ochami nodes.yaml
+      ansible.builtin.template:
+        src: nodes.yaml.j2
+        dest: '{{ openchami_work_dir }}/nodes/nodes.yaml'
+        mode: '{{ file_perm_rw }}'
+
+    - name: Drop ochami groups.yaml
+      template:
+        src: groups.yaml.j2
+        dest: '{{ openchami_work_dir }}/nodes/groups.yaml'
+        mode: '{{ file_perm_rw }}'
+
+    - name: Discover ochami nodes
+      block:
+        - name: Discover ochami nodes
+          ansible.builtin.shell: |
+            ochami discover static -f yaml -d @{{ openchami_work_dir }}/nodes/nodes.yaml --overwrite
+          changed_when: true
+          register: openchami_discover
+      rescue:
+        - name: Failed to discover nodes
+          ansible.builtin.debug:
+            msg: "Failed to discover nodes. Update inventory/group_vars/ochami/nodes.yaml with only new nodes and re-run the playbook. Error: {{ openchami_discover.stderr_lines }}"
+
+    - name: Verify node created in smd
+      ansible.builtin.shell: |
+        ochami smd component get | jq '.Components[] | select(.Type == "Node")'
+      changed_when: true
+      register: openchami_smd_status
+
+    - name: Openchami smd status output
+      ansible.builtin.debug:
+        msg: "{{ openchami_smd_status.stdout_lines }}"
+
+    - name: "Get SMD group data"
+      ansible.builtin.shell: |
+        /usr/bin/ochami smd group get
+      register: smd_group_data
+
+    - name: "Convert SMD data to ansible variable"
+      ansible.builtin.set_fact:
+        existing_smd_groups: '{{ smd_group_data.stdout | from_json }}'
+
+    - name: "Get existing SMD groups"
+      ansible.builtin.set_fact:
+        existing_smd_group_names: "{{ existing_smd_groups | map(attribute='label')| list  }}"
+
+    - name: "POST new SMD groups"
+      ansible.builtin.shell: |
+        /usr/bin/ochami smd group add -m {{ item.value | join(",") }} {{ item.key }}
+      when: item.key not in existing_smd_group_names
+      with_items:
+        - '{{ ochami_groups | dict2items }}'
+
+    - name: Check for group updates
+      ansible.builtin.include_tasks: update_smd_groups.yaml
+      with_items: '{{ ochami_groups | default({}) | dict2items }}'
+      loop_control:
+        loop_var: grp
+        label: '{{ grp.key }}'
+      when:
+        - grp.key in existing_smd_group_names

--- a/dell/podman-quadlets/roles/smd/tasks/update_smd_groups.yaml
+++ b/dell/podman-quadlets/roles/smd/tasks/update_smd_groups.yaml
@@ -1,0 +1,34 @@
+- name: '{{ grp.key }} | Get SMD group data'
+  ansible.builtin.set_fact:
+    smd_group_members: >-
+      {{ (existing_smd_groups | selectattr("label", "==", grp.key) | first).members.ids }}
+  no_log: true
+
+- name: '{{ grp.key }} | Get inventory content'
+  ansible.builtin.set_fact:
+    inventory_group_members: '{{ grp.value }}'
+  no_log: true
+
+- name: '{{ grp.key }} | Set changed if contents do not match'
+  ansible.builtin.set_fact:
+    smd_group_changed: true
+  when: smd_group_members | symmetric_difference(inventory_group_members) | length  > 0
+  no_log: true
+
+- name: debug
+  ansible.builtin.debug:
+    msg: '{{ grp }}'
+
+- name: '{{ grp.key }} | DELETE group'
+  ansible.builtin.shell: |
+      /usr/bin/ochami smd group delete --no-confirm {{ grp.key }}
+  changed_when: true
+  when:
+    - smd_group_changed | default(false) | bool
+
+- name: '{{ grp.key }} | POST group'
+  ansible.builtin.shell: |
+    /usr/bin/ochami smd group add -m {{ grp.value | join(",") }} {{ grp.key }}
+  changed_when: true
+  when:
+    - smd_group_changed | default(false) | bool

--- a/dell/podman-quadlets/roles/smd/templates/groups.yaml.j2
+++ b/dell/podman-quadlets/roles/smd/templates/groups.yaml.j2
@@ -1,0 +1,11 @@
+{% for item in ochami_groups | dict2items %}
+- label: {{ item.key }}
+{% if item.description is defined %}
+  description: {{ item.description }}
+{% endif %}
+  members:
+    ids:
+{% for m in item.value %}
+      - {{ m }}
+{% endfor %}
+{% endfor %}

--- a/dell/podman-quadlets/roles/smd/templates/nodes.yaml.j2
+++ b/dell/podman-quadlets/roles/smd/templates/nodes.yaml.j2
@@ -1,0 +1,2 @@
+nodes:
+{{ nodes | to_nice_yaml }}

--- a/dell/podman-quadlets/smd.yaml
+++ b/dell/podman-quadlets/smd.yaml
@@ -1,0 +1,4 @@
+- name: 'ochami configuration'
+  hosts: ochami
+  roles:
+    - { role: smd, tags: ['smd'] }


### PR DESCRIPTION
1. Support for installing openchami in RHEL 10 - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%201/Readme.md and Creating the s3 bucket and registry - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%201/Readme.md#11-set-up-storage-directories
   - Created `configs` role and created `configs.yml` playbook.
   - Integrated with `ochami_playbook.yml` and can be invoked with tags `configs`

2. Discover of nodes - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%202/Readme.md#223-discover-your-nodes

   - Created `smd` role and created `smd.yml` playbook.
   - Integrated with `ochami_playbook.yml` and can be invoked with tags `smd`

3. Build base and compute image for RHEL10 - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%202/Readme.md#24-building-system-images

   - Created `image` role and created `image.yml` playbook.
   - Integrated with `ochami_playbook.yml` and can be invoked with tags `image`

4. Configuring boot script for all the nodes - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%202/Readme.md#25-managing-boot-parameters

   - Created `bss` role and created `bss.yml` playbook.
   - Integrated with `ochami_playbook.yml` and can be invoked with tags `bss`

5. Configuring cloud init for all the nodes - https://github.com/OpenCHAMI/tutorial-2025/blob/main/Phase%202/Readme.md#25-managing-boot-parameters

   - Created `cloud_init` role and created `cloud_init.yml` playbook.
   - Integrated with `ochami_playbook.yml` and can be invoked with tags `cloud_init`

6. Created inputs for the all playbooks under groups_vars
7. Playbook is written as a framework to be utilized by any other project.