### PR TITLE
dell/podman-quadlets: move image-build invocation to variables

### DIFF
--- a/dell/podman-quadlets/roles/image/defaults/main.yaml
+++ b/dell/podman-quadlets/roles/image/defaults/main.yaml
@@ -11,3 +11,5 @@ image_build_fail_msg: "Error encountered while building image. This can be due t
 rhel_base_compute_mounts: "-v {{ openchami_work_dir }}/images/{{ rhel_base_compute_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z"
 rhel_base_mounts: "-v {{ openchami_work_dir }}/images/{{ rhel_base_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z"
 image_build_name: "ghcr.io/openchami/image-build:latest"
+rhel_base_command_options: "image-build --config config.yaml --log-level DEBUG"
+rhel_base_compute_command_options: "image-build --config config.yaml --log-level DEBUG"

--- a/dell/podman-quadlets/roles/image/tasks/base_compute_image.yaml
+++ b/dell/podman-quadlets/roles/image/tasks/base_compute_image.yaml
@@ -14,7 +14,7 @@
           --network host -e S3_ACCESS={{ minio_s3_username }} -e S3_SECRET={{ minio_s3_password }}
           {{ rhel_base_compute_mounts }}
           {{ image_build_name }}
-          image-build --config config.yaml --log-level DEBUG
+          {{ rhel_base_compute_command_options }}
       changed_when: true
       register: build_base_compute_osimage
   rescue:

--- a/dell/podman-quadlets/roles/image/tasks/base_image.yaml
+++ b/dell/podman-quadlets/roles/image/tasks/base_image.yaml
@@ -20,7 +20,7 @@
           --network host
           {{ rhel_base_mounts }}
           {{ image_build_name }}
-          image-build --config config.yaml --log-level DEBUG
+          {{ rhel_base_command_options }}
       changed_when: true
       register: build_base_osimage
   rescue:


### PR DESCRIPTION
Move `image-build` invocation in dell/podman-quadlets so the invocation is not hard-coded in various places.