### PR TITLE
Update MinIO and registry images to fixed tagged versions

### DIFF
--- a/dell/podman-quadlets/roles/configs/templates/minio/minio.service.j2
+++ b/dell/podman-quadlets/roles/configs/templates/minio/minio.service.j2
@@ -5,7 +5,7 @@ Wants=local-fs.target network-online.target
 
 [Container]
 ContainerName=minio-server
-Image=docker.io/minio/minio:latest
+Image=docker.io/pgsty/minio:RELEASE.2026-04-17T00-00-00Z
 # Volumes
 Volume={{ data_s3_dir }}:/data:Z
 

--- a/dell/podman-quadlets/roles/configs/templates/registry/registry.service.j2
+++ b/dell/podman-quadlets/roles/configs/templates/registry/registry.service.j2
@@ -6,7 +6,7 @@ Requires=network-online.target
 [Container]
 ContainerName=registry
 HostName=registry
-Image=docker.io/library/registry:latest
+Image=docker.io/library/registry:3.1.0
 Volume={{ data_oci_dir }}:/var/lib/registry:Z
 PublishPort=5000:5000
 


### PR DESCRIPTION
Update MinIO and registry container images to use specific fixed tagged versions instead of floating or latest tags to ensure deployment stability